### PR TITLE
Introduce upsert_wallet_as_owner

### DIFF
--- a/schema.playground.kf
+++ b/schema.playground.kf
@@ -62,9 +62,11 @@ action add_human_as_owner($id) public { // this is temporary for easy adding use
     INSERT INTO humans (id) VALUES ($id);
 }
 
-action add_wallet_as_owner($id, $human_id, $address, $public_key, $message, $signature) owner public {
+action upsert_wallet_as_owner($id, $human_id, $address, $public_key, $message, $signature) owner public {
     INSERT INTO wallets (id, human_id, address, public_key, message, signature)
-    VALUES ($id, $human_id, $address, $public_key, $message, $signature);
+    VALUES ($id, $human_id, $address, $public_key, $message, $signature)
+    ON CONFLICT(id) DO UPDATE
+    SET human_id=$human_id, address=$address, public_key=$public_key, message=$message, signature=$signature;
 }
 
 action upsert_credential_as_owner($id, $human_id, $issuer, $credential_type, $content, $encryption_public_key) owner public {

--- a/schema.production.kf
+++ b/schema.production.kf
@@ -62,9 +62,11 @@ action add_human_as_owner($id) public { // this is temporary for easy adding use
     INSERT INTO humans (id) VALUES ($id);
 }
 
-action add_wallet_as_owner($id, $human_id, $address, $public_key, $message, $signature) owner public {
+action upsert_wallet_as_owner($id, $human_id, $address, $public_key, $message, $signature) owner public {
     INSERT INTO wallets (id, human_id, address, public_key, message, signature)
-    VALUES ($id, $human_id, $address, $public_key, $message, $signature);
+    VALUES ($id, $human_id, $address, $public_key, $message, $signature)
+    ON CONFLICT(id) DO UPDATE
+    SET human_id=$human_id, address=$address, public_key=$public_key, message=$message, signature=$signature;
 }
 
 action upsert_credential_as_owner($id, $human_id, $issuer, $credential_type, $content, $encryption_public_key) owner public {

--- a/schema.staging.kf
+++ b/schema.staging.kf
@@ -62,9 +62,11 @@ action add_human_as_owner($id) public { // this is temporary for easy adding use
     INSERT INTO humans (id) VALUES ($id);
 }
 
-action add_wallet_as_owner($id, $human_id, $address, $public_key, $message, $signature) owner public {
+action upsert_wallet_as_owner($id, $human_id, $address, $public_key, $message, $signature) owner public {
     INSERT INTO wallets (id, human_id, address, public_key, message, signature)
-    VALUES ($id, $human_id, $address, $public_key, $message, $signature);
+    VALUES ($id, $human_id, $address, $public_key, $message, $signature)
+    ON CONFLICT(id) DO UPDATE
+    SET human_id=$human_id, address=$address, public_key=$public_key, message=$message, signature=$signature;
 }
 
 action upsert_credential_as_owner($id, $human_id, $issuer, $credential_type, $content, $encryption_public_key) owner public {


### PR DESCRIPTION
Context: https://app.asana.com/0/1204479969653186/1205834045903796/f

cc: @narrthzen because this will beget migrations everywhere. Please advise on the best way to proceed.

This doesn't buy us much, but it makes all actions that happen in a background worker look the same. That'll make the system easier to reason about.

The tx issuer still needs to make sure that the human is added before calling the action.