### PR TITLE
Don't return duplicates on get_credentials

### DIFF
--- a/schema.development.kf
+++ b/schema.development.kf
@@ -162,7 +162,7 @@ action get_credentials() public view mustsign {
     FROM credentials AS c
     LEFT JOIN shared_credentials AS sc ON c.id = sc.duplicate_id
     INNER JOIN wallets ON c.human_id = wallets.human_id
-    WHERE wallets.address = address(@caller) COLLATE NOCASE OR wallets.public_key = public_key(@caller, 'base64') COLLATE NOCASE;
+    WHERE (wallets.address = address(@caller) COLLATE NOCASE OR wallets.public_key = public_key(@caller, 'base64') COLLATE NOCASE) AND sc.duplicate_id IS NULL;
 }
 
 action add_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public mustsign {


### PR DESCRIPTION
I ran into this when developing https://github.com/idos-network/idos-sdk-js/pull/95.

Was this just an oversight because we hadn't exercised sharing before, or am I misinterpreting something?