### PR TITLE
Update to Kwil 0.6.6

### DIFF
--- a/schema.development.kf
+++ b/schema.development.kf
@@ -327,7 +327,7 @@ action add_wallet($id, $address, $public_key, $message, $signature) public {
         ),
         $address,
         CASE
-            WHEN $public_key = '' OR $public_key = NULL THEN NULL
+            WHEN $public_key = '' THEN NULL
             ELSE $public_key
         END,
         $wallet_type,

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -74,7 +74,7 @@ action upsert_wallet_as_owner($id, $human_id, $address, $public_key, $wallet_typ
     INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
     VALUES ($id, $human_id, $address, $public_key, $wallet_type, $message, $signature)
     ON CONFLICT(id) DO UPDATE
-    SET human_id=$human_id, address=$address, public_key=$public_key, message=$message, signature=$signature;
+    SET human_id=$human_id, address=$address, public_key=$public_key,  wallet_type=$wallet_type, message=$message, signature=$signature;
 }
 
 action upsert_credential_as_owner($id, $human_id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) owner public {

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -66,10 +66,10 @@ action add_human_as_owner($id) owner public {
 }
 
 action upsert_wallet_as_owner($id, $human_id, $address, $public_key, $wallet_type, $message, $signature) owner public {
-    SELECT CASE
-        WHEN $wallet_type = 'NEAR' AND ($public_key IS NULL OR length($public_key) != 52)
-        THEN ERROR('NEAR wallets require a valid public_key to be given.')
-    END;
+    SELECT CASE WHEN $wallet_type = 'NEAR' AND $public_key IS NULL THEN ERROR('NEAR wallets require a public_key to be given.') END;
+
+    $valid_near_public_key = idos_near.is_valid_public_key($public_key);
+    SELECT CASE WHEN $wallet_type = 'NEAR' AND $valid_near_public_key != 1 THEN ERROR('Invalid or unsupported public key.') END;
 
     INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
     VALUES ($id, $human_id, $address, $public_key, $wallet_type, $message, $signature)
@@ -318,10 +318,10 @@ action add_wallet($id, $address, $public_key, $message, $signature) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     $wallet_type = idos_near.determine_wallet_type($address);
 
-    SELECT CASE
-        WHEN $wallet_type = 'NEAR' AND ($public_key IS NULL OR length($public_key) != 52)
-        THEN ERROR('NEAR wallets require a valid public_key to be given.')
-    END;
+    SELECT CASE WHEN $wallet_type = 'NEAR' AND $public_key IS NULL THEN ERROR('NEAR wallets require a public_key to be given.') END;
+
+    $valid_near_public_key = idos_near.is_valid_public_key($public_key);
+    SELECT CASE WHEN $wallet_type = 'NEAR' AND $valid_near_public_key != 1 THEN ERROR('Invalid or unsupported public key.') END;
 
     INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
     VALUES (

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -33,8 +33,9 @@ table shared_human_attributes {
 table wallets {
     id text primary minlen(36) maxlen(36) notnull unique,
     human_id text minlen(36) maxlen(36) notnull,
-    address text notnull,
-    public_key text notnull,
+    address text,
+    public_key text,
+    wallet_type text notnull,
     message text,
     signature text,
     foreign_key (human_id) references humans(id) on_delete cascade
@@ -60,13 +61,13 @@ table shared_credentials {
     foreign_key (duplicate_id) references credentials(id) on_delete cascade
 }
 
-action add_human_as_owner($id) public { // this is temporary for easy adding users not through nautilus for test purposes
+action add_human_as_owner($id) owner public { // this is temporary for easy adding users not through nautilus for test purposes
     INSERT INTO humans (id) VALUES ($id);
 }
 
-action upsert_wallet_as_owner($id, $human_id, $address, $public_key, $message, $signature) owner public {
-    INSERT INTO wallets (id, human_id, address, public_key, message, signature)
-    VALUES ($id, $human_id, $address, $public_key, $message, $signature)
+action upsert_wallet_as_owner($id, $human_id, $address, $public_key, $wallet_type, $message, $signature) owner public {
+    INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
+    VALUES ($id, $human_id, $address, $public_key, $wallet_type, $message, $signature)
     ON CONFLICT(id) DO UPDATE
     SET human_id=$human_id, address=$address, public_key=$public_key, message=$message, signature=$signature;
 }
@@ -82,19 +83,29 @@ action delete_human_as_owner($id) owner public { //for testing period, for not t
     DELETE FROM humans WHERE id=$id;
 }
 
-action get_attributes() public view mustsign {
+@kgw(authn='true')
+action get_attributes() public view {
+    $converted = idos_near.hex_to_base58(@caller);
 	SELECT DISTINCT ha.id, ha.human_id, ha.attribute_key, ha.value, sha.original_id AS original_id
     FROM human_attributes AS ha
     LEFT JOIN shared_human_attributes AS sha ON ha.id = sha.duplicate_id
     INNER JOIN wallets ON ha.human_id = wallets.human_id
-    WHERE wallets.address = address(@caller) COLLATE NOCASE OR wallets.public_key = public_key(@caller, 'base64') COLLATE NOCASE;
+    WHERE (
+        wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE
+    ) OR (
+        wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted
+    );
 }
 
-action add_attribute($id, $attribute_key, $value) public mustsign {
+@kgw(authn='true')
+action add_attribute($id, $attribute_key, $value) public {
+    $converted = idos_near.hex_to_base58(@caller);
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
     VALUES (
         $id,
-        (SELECT DISTINCT human_id FROM wallets WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE),
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = $converted)
+        ),
         $attribute_key,
         $value
     );
@@ -110,41 +121,47 @@ action add_attribute_as_owner($id, $human_id, $attribute_key, $value) owner publ
     );
 }
 
-action edit_attribute($id, $attribute_key, $value) public mustsign {
+@kgw(authn='true')
+action edit_attribute($id, $attribute_key, $value) public {
+    $converted = idos_near.hex_to_base58(@caller);
     UPDATE human_attributes
     SET attribute_key=$attribute_key, value=$value
     WHERE id=$id
-    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE);
-}
-
-action remove_attribute($id) public mustsign {
-    DELETE FROM human_attributes
-    WHERE id=$id
-    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE);
-}
-
-action get_wallets() public view mustsign {
-    SELECT DISTINCT w1.*
-    FROM wallets AS w1
-    INNER JOIN wallets AS w2 ON w1.human_id = w2.human_id
-    WHERE w2.address = address(@caller) COLLATE NOCASE OR w2.public_key = public_key(@caller, 'base64') COLLATE NOCASE;
-}
-
-action add_wallet($id, $address, $message, $signature) public mustsign {
-    INSERT INTO wallets (id, human_id, address, public_key, message, signature)
-    VALUES (
-        $id,
-        (SELECT DISTINCT human_id FROM wallets WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE),
-        $address,
-        public_key(@caller, 'base64'),
-        $message,
-        $signature
+    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
     );
 }
 
-action remove_wallet($id) public mustsign {
+@kgw(authn='true')
+action remove_attribute($id) public {
+    $converted = idos_near.hex_to_base58(@caller);
+    DELETE FROM human_attributes
+    WHERE id=$id
+    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
+    );
+}
+
+@kgw(authn='true')
+action get_wallets() public view {
+    $converted = idos_near.hex_to_base58(@caller);
+    SELECT DISTINCT w1.*
+    FROM wallets AS w1
+    INNER JOIN wallets AS w2 ON w1.human_id = w2.human_id
+    WHERE (
+        w2.wallet_type = 'EVM' AND w2.address = @caller COLLATE NOCASE
+    ) OR (
+        w2.wallet_type = 'NEAR' AND w2.public_key = $converted
+    );
+}
+
+@kgw(authn='true')
+action remove_wallet($id) public {
+    $converted = idos_eth.hex_to_base58(@caller);
     DELETE FROM wallets
-    WHERE id=$id AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE);
+    WHERE id=$id AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
+    );
 }
 
 action has_profile($address) public view {
@@ -153,23 +170,37 @@ action has_profile($address) public view {
     ) AS has_profile;
 }
 
-action get_wallet_human_id() public view mustsign {
+@kgw(authn='true')
+action get_wallet_human_id() public view {
+    $converted = idos_eth.hex_to_base58(@caller);
     SELECT DISTINCT human_id FROM wallets
-    WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE;
+    WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted);
 }
-action get_credentials() public view mustsign {
+
+@kgw(authn='true')
+action get_credentials() public view {
+    $converted = idos_eth.hex_to_base58(@caller);
 	SELECT DISTINCT c.id, c.human_id, c.issuer, c.credential_type, c.credential_level, c.credential_status, sc.original_id AS original_id
     FROM credentials AS c
     LEFT JOIN shared_credentials AS sc ON c.id = sc.duplicate_id
     INNER JOIN wallets ON c.human_id = wallets.human_id
-    WHERE wallets.address = address(@caller) COLLATE NOCASE OR wallets.public_key = public_key(@caller, 'base64') COLLATE NOCASE;
+    WHERE (
+        wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE
+    ) OR (
+        wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted
+    );
 }
 
-action add_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public mustsign {
+@kgw(authn='true')
+action add_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
+    $converted = idos_eth.hex_to_base58(@caller);
     INSERT INTO credentials (id, human_id, issuer, credential_type, credential_level, credential_status, content, encryption_public_key)
     VALUES (
         $id,
-        (SELECT DISTINCT human_id from wallets WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE),
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = $converted)
+        ),
         $issuer,
         $credential_type,
         $credential_level,
@@ -179,11 +210,15 @@ action add_credential($id, $issuer, $credential_type, $credential_level, $creden
     );
 }
 
-action share_credential($id, $original_credential_id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public mustsign {
+@kgw(authn='true')
+action share_credential($id, $original_credential_id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
+    $converted = idos_eth.hex_to_base58(@caller);
     INSERT INTO credentials (id, human_id, issuer, credential_type, credential_level, credential_status, content, encryption_public_key)
     VALUES (
         $id,
-        (SELECT DISTINCT human_id from wallets WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE),
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = $converted)
+        ),
         $issuer,
         $credential_type,
         $credential_level,
@@ -195,30 +230,44 @@ action share_credential($id, $original_credential_id, $issuer, $credential_type,
     add_shared_credential($original_credential_id, $id);
 }
 
-action edit_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public mustsign {
+@kgw(authn='true')
+action edit_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
+    $converted = idos_eth.hex_to_base58(@caller);
     UPDATE credentials
     SET issuer=$issuer, credential_type=$credential_type, credential_level=$credential_level, credential_status=$credential_status, content=$content, encryption_public_key=$encryption_public_key
     WHERE id=$id
-    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE);
+    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
+    );
 }
 
-action remove_credential($id) public mustsign {
+@kgw(authn='true')
+action remove_credential($id) public {
+    $converted = idos_eth.hex_to_base58(@caller);
     DELETE FROM credentials
     WHERE id=$id
-    AND human_id=(SELECT human_id FROM wallets WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE);
+    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
+    );
 }
 
-action get_credential_owned ($id) public view mustsign {
+@kgw(authn='true')
+action get_credential_owned ($id) public view {
+    $converted = idos_eth.hex_to_base58(@caller);
     SELECT DISTINCT credentials.*
     FROM credentials
     INNER JOIN wallets ON credentials.human_id = wallets.human_id
     WHERE credentials.id = $id
-    AND (wallets.address = address(@caller) COLLATE NOCASE OR wallets.public_key = public_key(@caller, 'base64') COLLATE NOCASE);
+    AND (
+        (wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE)
+            OR (wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted)
+    );
 }
 
-action get_credential_shared ($id) public view mustsign {
-    $has_grant_on_eth = idos_eth.has_grants(address(@caller), $id);
-    $has_grant_on_near = idos_near.has_grants(address(@caller), $id);
+@kgw(authn='true')
+action get_credential_shared ($id) public view {
+    $has_grant_on_eth = idos_eth.has_grants(@caller, $id);
+    $has_grant_on_near = idos_near.has_grants(@caller, $id);
 
     SELECT CASE
         WHEN $has_grant_on_eth != 1 AND $has_grant_on_near != 1
@@ -229,11 +278,15 @@ action get_credential_shared ($id) public view mustsign {
     WHERE id = $id;
 }
 
-action share_attribute($id, $original_attribute_id, $attribute_key, $value) public mustsign {
+@kgw(authn='true')
+action share_attribute($id, $original_attribute_id, $attribute_key, $value) public {
+    $converted = idos_eth.hex_to_base58(@caller);
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
     VALUES (
         $id,
-        (SELECT DISTINCT human_id from wallets WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE),
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = $converted)
+        ),
         $attribute_key,
         $value
     );
@@ -249,4 +302,28 @@ action add_shared_credential($original_id, $duplicate_id) owner public {
 action add_shared_attribute($original_id, $duplicate_id) owner public {
     INSERT INTO shared_human_attributes (original_id, duplicate_id)
     VALUES ($original_id, $duplicate_id);
+}
+
+@kgw(authn='true')
+action add_wallet($id, $address, $message, $signature) public {
+    $converted = idos_near.hex_to_base58(@caller);
+    $wallet_type = idos_near.determine_wallet_type($address);
+    INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
+    VALUES (
+        $id,
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = $converted)
+        ),
+        $address,
+        NULL,
+        $wallet_type,
+        $message,
+        $signature
+    );
+}
+
+@kgw(authn='true')
+action show_caller() public view {
+    $converted = idos_eth.hex_to_base58(@caller);
+    SELECT @caller, $converted;
 }

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -88,6 +88,10 @@ action delete_human_as_owner($id) owner public { //for testing period, for not t
     DELETE FROM humans WHERE id=$id;
 }
 
+action delete_wallet_as_owner($id) owner public { //temporary, to remove wrong data from initial test period
+    DELETE FROM wallets WHERE id=$id;
+}
+
 @kgw(authn='true')
 action get_attributes() public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -91,26 +91,23 @@ action delete_human_as_owner($id) owner public { //for testing period, for not t
 @kgw(authn='true')
 action get_attributes() public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
 	SELECT DISTINCT ha.id, ha.human_id, ha.attribute_key, ha.value, sha.original_id AS original_id
     FROM human_attributes AS ha
     LEFT JOIN shared_human_attributes AS sha ON ha.id = sha.duplicate_id
-    INNER JOIN wallets ON ha.human_id = wallets.human_id
-    WHERE (
-        wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE
-    ) OR (
-        wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted
-    );
+    WHERE ha.human_id = $current_human_id;
 }
 
 @kgw(authn='true')
 action add_attribute($id, $attribute_key, $value) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
     VALUES (
         $id,
-        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-            OR (wallet_type = 'NEAR' AND public_key = $converted)
-        ),
+        $current_human_id,
         $attribute_key,
         $value
     );
@@ -129,44 +126,41 @@ action add_attribute_as_owner($id, $human_id, $attribute_key, $value) owner publ
 @kgw(authn='true')
 action edit_attribute($id, $attribute_key, $value) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
     UPDATE human_attributes
     SET attribute_key=$attribute_key, value=$value
     WHERE id=$id
-    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted)
-    );
+    AND human_id=$current_human_id;
 }
 
 @kgw(authn='true')
 action remove_attribute($id) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
     DELETE FROM human_attributes
     WHERE id=$id
-    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted)
-    );
+    AND human_id=$current_human_id;
 }
 
 @kgw(authn='true')
 action get_wallets() public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    SELECT DISTINCT w1.*
-    FROM wallets AS w1
-    INNER JOIN wallets AS w2 ON w1.human_id = w2.human_id
-    WHERE (
-        w2.wallet_type = 'EVM' AND w2.address = @caller COLLATE NOCASE
-    ) OR (
-        w2.wallet_type = 'NEAR' AND w2.public_key = $converted
-    );
+    $current_human_id = caller_human_id();
+
+    SELECT *
+    FROM wallets
+    WHERE human_id=$current_human_id;
 }
 
 @kgw(authn='true')
 action remove_wallet($id) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
     DELETE FROM wallets
-    WHERE id=$id AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted)
-    );
+    WHERE id=$id AND human_id=$current_human_id;
 }
 
 action has_profile($address) public view {
@@ -178,34 +172,31 @@ action has_profile($address) public view {
 @kgw(authn='true')
 action get_wallet_human_id() public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    SELECT DISTINCT human_id FROM wallets
-    WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted);
+    $current_human_id = caller_human_id();
+
+    SELECT $current_human_id as human_id;
 }
 
 @kgw(authn='true')
 action get_credentials() public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
 	SELECT DISTINCT c.id, c.human_id, c.issuer, c.credential_type, c.credential_level, c.credential_status, sc.original_id AS original_id
     FROM credentials AS c
     LEFT JOIN shared_credentials AS sc ON c.id = sc.duplicate_id
-    INNER JOIN wallets ON c.human_id = wallets.human_id
-    WHERE (
-        wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE
-    ) OR (
-        wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted
-    );
+    WHERE c.human_id = $current_human_id;
 }
 
 @kgw(authn='true')
 action add_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
     INSERT INTO credentials (id, human_id, issuer, credential_type, credential_level, credential_status, content, encryption_public_key)
     VALUES (
         $id,
-        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-            OR (wallet_type = 'NEAR' AND public_key = $converted)
-        ),
+        $current_human_id,
         $issuer,
         $credential_type,
         $credential_level,
@@ -218,12 +209,12 @@ action add_credential($id, $issuer, $credential_type, $credential_level, $creden
 @kgw(authn='true')
 action share_credential($id, $original_credential_id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
     INSERT INTO credentials (id, human_id, issuer, credential_type, credential_level, credential_status, content, encryption_public_key)
     VALUES (
         $id,
-        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-            OR (wallet_type = 'NEAR' AND public_key = $converted)
-        ),
+        $current_human_id,
         $issuer,
         $credential_type,
         $credential_level,
@@ -238,35 +229,33 @@ action share_credential($id, $original_credential_id, $issuer, $credential_type,
 @kgw(authn='true')
 action edit_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
     UPDATE credentials
     SET issuer=$issuer, credential_type=$credential_type, credential_level=$credential_level, credential_status=$credential_status, content=$content, encryption_public_key=$encryption_public_key
     WHERE id=$id
-    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted)
-    );
+    AND human_id=$current_human_id;
 }
 
 @kgw(authn='true')
 action remove_credential($id) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
     DELETE FROM credentials
     WHERE id=$id
-    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted)
-    );
+    AND human_id=$current_human_id;
 }
 
 @kgw(authn='true')
 action get_credential_owned ($id) public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
     SELECT DISTINCT credentials.*
     FROM credentials
-    INNER JOIN wallets ON credentials.human_id = wallets.human_id
     WHERE credentials.id = $id
-    AND (
-        (wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE)
-            OR (wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted)
-    );
+    AND credentials.human_id = $current_human_id;
 }
 
 @kgw(authn='true')
@@ -286,12 +275,12 @@ action get_credential_shared ($id) public view {
 @kgw(authn='true')
 action share_attribute($id, $original_attribute_id, $attribute_key, $value) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
     VALUES (
         $id,
-        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-            OR (wallet_type = 'NEAR' AND public_key = $converted)
-        ),
+        $current_human_id,
         $attribute_key,
         $value
     );
@@ -313,6 +302,7 @@ action add_shared_attribute($original_id, $duplicate_id) owner public {
 action add_wallet($id, $address, $public_key, $message, $signature) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     $wallet_type = idos_near.determine_wallet_type($address);
+    $current_human_id = caller_human_id();
 
     SELECT CASE
         WHEN $wallet_type = 'NEAR' AND ($public_key IS NULL OR length($public_key) != 52)
@@ -322,9 +312,7 @@ action add_wallet($id, $address, $public_key, $message, $signature) public {
     INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
     VALUES (
         $id,
-        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-            OR (wallet_type = 'NEAR' AND public_key = $converted)
-        ),
+        $current_human_id,
         $address,
         CASE
             WHEN $public_key = '' THEN NULL
@@ -340,4 +328,14 @@ action add_wallet($id, $address, $public_key, $message, $signature) public {
 action show_caller() public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT @caller, $converted;
+}
+
+action caller_human_id() private view {
+    $converted = idos_near.implicit_address_to_public_key(@caller);
+    SELECT human_id
+    FROM wallets
+    WHERE
+        (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
+    LIMIT 1;
 }

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -61,7 +61,7 @@ table shared_credentials {
     foreign_key (duplicate_id) references credentials(id) on_delete cascade
 }
 
-action add_human_as_owner($id) owner public { // this is temporary for easy adding users not through nautilus for test purposes
+action add_human_as_owner($id) owner public {
     INSERT INTO humans (id) VALUES ($id);
 }
 

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -1,7 +1,7 @@
 database idos;
 
 use idos {
-    registry_address: '0xd75fE3089a983fDB28a18BaB3ff625a6a49C0C00',
+    registry_address: '0x4D9DE1bb481B9dA37A7a7E3a07F6f60654fEe7BB',
     chain: 'eth'
 } as idos_eth;
 
@@ -33,7 +33,7 @@ table shared_human_attributes {
 table wallets {
     id text primary minlen(36) maxlen(36) notnull unique,
     human_id text minlen(36) maxlen(36) notnull,
-    address text,
+    address text notnull,
     public_key text,
     wallet_type text notnull,
     message text,
@@ -305,7 +305,7 @@ action add_shared_attribute($original_id, $duplicate_id) owner public {
 }
 
 @kgw(authn='true')
-action add_wallet($id, $address, $message, $signature) public {
+action add_wallet($id, $address, $public_key, $message, $signature) public {
     $converted = idos_near.hex_to_base58(@caller);
     $wallet_type = idos_near.determine_wallet_type($address);
     INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
@@ -315,7 +315,10 @@ action add_wallet($id, $address, $message, $signature) public {
             OR (wallet_type = 'NEAR' AND public_key = $converted)
         ),
         $address,
-        NULL,
+        CASE
+            WHEN $public_key = '' OR $public_key = NULL THEN NULL
+            ELSE $public_key
+        END,
         $wallet_type,
         $message,
         $signature

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -1,7 +1,7 @@
 database idos;
 
 use idos {
-    registry_address: '0x4D9DE1bb481B9dA37A7a7E3a07F6f60654fEe7BB',
+    registry_address: '0xd75fE3089a983fDB28a18BaB3ff625a6a49C0C00',
     chain: 'eth'
 } as idos_eth;
 

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -339,9 +339,3 @@ action add_wallet($id, $address, $public_key, $message, $signature) public {
         $signature
     );
 }
-
-@kgw(authn='true')
-action show_caller() public view {
-    $converted = idos_near.implicit_address_to_public_key(@caller);
-    SELECT @caller, $converted;
-}

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -66,6 +66,11 @@ action add_human_as_owner($id) owner public {
 }
 
 action upsert_wallet_as_owner($id, $human_id, $address, $public_key, $wallet_type, $message, $signature) owner public {
+    SELECT CASE
+        WHEN $wallet_type = "NEAR" AND length($public_key) != 52
+        THEN ERROR('NEAR wallets require a valid public_key to be given.')
+    END;
+
     INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
     VALUES ($id, $human_id, $address, $public_key, $wallet_type, $message, $signature)
     ON CONFLICT(id) DO UPDATE
@@ -308,6 +313,12 @@ action add_shared_attribute($original_id, $duplicate_id) owner public {
 action add_wallet($id, $address, $public_key, $message, $signature) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     $wallet_type = idos_near.determine_wallet_type($address);
+
+    SELECT CASE
+        WHEN $wallet_type = "NEAR" AND length($public_key) != 52
+        THEN ERROR('NEAR wallets require a valid public_key to be given.')
+    END;
+
     INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
     VALUES (
         $id,

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -95,23 +95,26 @@ action delete_wallet_as_owner($id) owner public { //temporary, to remove wrong d
 @kgw(authn='true')
 action get_attributes() public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
 	SELECT DISTINCT ha.id, ha.human_id, ha.attribute_key, ha.value, sha.original_id AS original_id
     FROM human_attributes AS ha
     LEFT JOIN shared_human_attributes AS sha ON ha.id = sha.duplicate_id
-    WHERE ha.human_id = $current_human_id;
+    INNER JOIN wallets ON ha.human_id = wallets.human_id
+    WHERE (
+        wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE
+    ) OR (
+        wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted
+    );
 }
 
 @kgw(authn='true')
 action add_attribute($id, $attribute_key, $value) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
     VALUES (
         $id,
-        $current_human_id,
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = $converted)
+        ),
         $attribute_key,
         $value
     );
@@ -130,41 +133,44 @@ action add_attribute_as_owner($id, $human_id, $attribute_key, $value) owner publ
 @kgw(authn='true')
 action edit_attribute($id, $attribute_key, $value) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
     UPDATE human_attributes
     SET attribute_key=$attribute_key, value=$value
     WHERE id=$id
-    AND human_id=$current_human_id;
+    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
+    );
 }
 
 @kgw(authn='true')
 action remove_attribute($id) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
     DELETE FROM human_attributes
     WHERE id=$id
-    AND human_id=$current_human_id;
+    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
+    );
 }
 
 @kgw(authn='true')
 action get_wallets() public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
-    SELECT *
-    FROM wallets
-    WHERE human_id=$current_human_id;
+    SELECT DISTINCT w1.*
+    FROM wallets AS w1
+    INNER JOIN wallets AS w2 ON w1.human_id = w2.human_id
+    WHERE (
+        w2.wallet_type = 'EVM' AND w2.address = @caller COLLATE NOCASE
+    ) OR (
+        w2.wallet_type = 'NEAR' AND w2.public_key = $converted
+    );
 }
 
 @kgw(authn='true')
 action remove_wallet($id) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
     DELETE FROM wallets
-    WHERE id=$id AND human_id=$current_human_id;
+    WHERE id=$id AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
+    );
 }
 
 action has_profile($address) public view {
@@ -176,31 +182,34 @@ action has_profile($address) public view {
 @kgw(authn='true')
 action get_wallet_human_id() public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
-    SELECT $current_human_id as human_id;
+    SELECT DISTINCT human_id FROM wallets
+    WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted);
 }
 
 @kgw(authn='true')
 action get_credentials() public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
 	SELECT DISTINCT c.id, c.human_id, c.issuer, c.credential_type, c.credential_level, c.credential_status, sc.original_id AS original_id
     FROM credentials AS c
     LEFT JOIN shared_credentials AS sc ON c.id = sc.duplicate_id
-    WHERE c.human_id = $current_human_id;
+    INNER JOIN wallets ON c.human_id = wallets.human_id
+    WHERE (
+        wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE
+    ) OR (
+        wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted
+    );
 }
 
 @kgw(authn='true')
 action add_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
     INSERT INTO credentials (id, human_id, issuer, credential_type, credential_level, credential_status, content, encryption_public_key)
     VALUES (
         $id,
-        $current_human_id,
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = $converted)
+        ),
         $issuer,
         $credential_type,
         $credential_level,
@@ -213,12 +222,12 @@ action add_credential($id, $issuer, $credential_type, $credential_level, $creden
 @kgw(authn='true')
 action share_credential($id, $original_credential_id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
     INSERT INTO credentials (id, human_id, issuer, credential_type, credential_level, credential_status, content, encryption_public_key)
     VALUES (
         $id,
-        $current_human_id,
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = $converted)
+        ),
         $issuer,
         $credential_type,
         $credential_level,
@@ -233,33 +242,35 @@ action share_credential($id, $original_credential_id, $issuer, $credential_type,
 @kgw(authn='true')
 action edit_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
     UPDATE credentials
     SET issuer=$issuer, credential_type=$credential_type, credential_level=$credential_level, credential_status=$credential_status, content=$content, encryption_public_key=$encryption_public_key
     WHERE id=$id
-    AND human_id=$current_human_id;
+    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
+    );
 }
 
 @kgw(authn='true')
 action remove_credential($id) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
     DELETE FROM credentials
     WHERE id=$id
-    AND human_id=$current_human_id;
+    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
+    );
 }
 
 @kgw(authn='true')
 action get_credential_owned ($id) public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
     SELECT DISTINCT credentials.*
     FROM credentials
+    INNER JOIN wallets ON credentials.human_id = wallets.human_id
     WHERE credentials.id = $id
-    AND credentials.human_id = $current_human_id;
+    AND (
+        (wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE)
+            OR (wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted)
+    );
 }
 
 @kgw(authn='true')
@@ -279,12 +290,12 @@ action get_credential_shared ($id) public view {
 @kgw(authn='true')
 action share_attribute($id, $original_attribute_id, $attribute_key, $value) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
     VALUES (
         $id,
-        $current_human_id,
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = $converted)
+        ),
         $attribute_key,
         $value
     );
@@ -306,7 +317,6 @@ action add_shared_attribute($original_id, $duplicate_id) owner public {
 action add_wallet($id, $address, $public_key, $message, $signature) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     $wallet_type = idos_near.determine_wallet_type($address);
-    $current_human_id = caller_human_id();
 
     SELECT CASE
         WHEN $wallet_type = 'NEAR' AND ($public_key IS NULL OR length($public_key) != 52)
@@ -316,7 +326,9 @@ action add_wallet($id, $address, $public_key, $message, $signature) public {
     INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
     VALUES (
         $id,
-        $current_human_id,
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = $converted)
+        ),
         $address,
         CASE
             WHEN $public_key = '' THEN NULL
@@ -332,14 +344,4 @@ action add_wallet($id, $address, $public_key, $message, $signature) public {
 action show_caller() public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT @caller, $converted;
-}
-
-action caller_human_id() private view {
-    $converted = idos_near.implicit_address_to_public_key(@caller);
-    SELECT human_id
-    FROM wallets
-    WHERE
-        (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted)
-    LIMIT 1;
 }

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -85,7 +85,7 @@ action delete_human_as_owner($id) owner public { //for testing period, for not t
 
 @kgw(authn='true')
 action get_attributes() public view {
-    $converted = idos_near.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
 	SELECT DISTINCT ha.id, ha.human_id, ha.attribute_key, ha.value, sha.original_id AS original_id
     FROM human_attributes AS ha
     LEFT JOIN shared_human_attributes AS sha ON ha.id = sha.duplicate_id
@@ -99,7 +99,7 @@ action get_attributes() public view {
 
 @kgw(authn='true')
 action add_attribute($id, $attribute_key, $value) public {
-    $converted = idos_near.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
     VALUES (
         $id,
@@ -123,7 +123,7 @@ action add_attribute_as_owner($id, $human_id, $attribute_key, $value) owner publ
 
 @kgw(authn='true')
 action edit_attribute($id, $attribute_key, $value) public {
-    $converted = idos_near.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     UPDATE human_attributes
     SET attribute_key=$attribute_key, value=$value
     WHERE id=$id
@@ -134,7 +134,7 @@ action edit_attribute($id, $attribute_key, $value) public {
 
 @kgw(authn='true')
 action remove_attribute($id) public {
-    $converted = idos_near.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     DELETE FROM human_attributes
     WHERE id=$id
     AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
@@ -144,7 +144,7 @@ action remove_attribute($id) public {
 
 @kgw(authn='true')
 action get_wallets() public view {
-    $converted = idos_near.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT DISTINCT w1.*
     FROM wallets AS w1
     INNER JOIN wallets AS w2 ON w1.human_id = w2.human_id
@@ -157,7 +157,7 @@ action get_wallets() public view {
 
 @kgw(authn='true')
 action remove_wallet($id) public {
-    $converted = idos_eth.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     DELETE FROM wallets
     WHERE id=$id AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
         OR (wallet_type = 'NEAR' AND public_key = $converted)
@@ -172,7 +172,7 @@ action has_profile($address) public view {
 
 @kgw(authn='true')
 action get_wallet_human_id() public view {
-    $converted = idos_eth.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT DISTINCT human_id FROM wallets
     WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
         OR (wallet_type = 'NEAR' AND public_key = $converted);
@@ -180,7 +180,7 @@ action get_wallet_human_id() public view {
 
 @kgw(authn='true')
 action get_credentials() public view {
-    $converted = idos_eth.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
 	SELECT DISTINCT c.id, c.human_id, c.issuer, c.credential_type, c.credential_level, c.credential_status, sc.original_id AS original_id
     FROM credentials AS c
     LEFT JOIN shared_credentials AS sc ON c.id = sc.duplicate_id
@@ -194,7 +194,7 @@ action get_credentials() public view {
 
 @kgw(authn='true')
 action add_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
-    $converted = idos_eth.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     INSERT INTO credentials (id, human_id, issuer, credential_type, credential_level, credential_status, content, encryption_public_key)
     VALUES (
         $id,
@@ -212,7 +212,7 @@ action add_credential($id, $issuer, $credential_type, $credential_level, $creden
 
 @kgw(authn='true')
 action share_credential($id, $original_credential_id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
-    $converted = idos_eth.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     INSERT INTO credentials (id, human_id, issuer, credential_type, credential_level, credential_status, content, encryption_public_key)
     VALUES (
         $id,
@@ -232,7 +232,7 @@ action share_credential($id, $original_credential_id, $issuer, $credential_type,
 
 @kgw(authn='true')
 action edit_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
-    $converted = idos_eth.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     UPDATE credentials
     SET issuer=$issuer, credential_type=$credential_type, credential_level=$credential_level, credential_status=$credential_status, content=$content, encryption_public_key=$encryption_public_key
     WHERE id=$id
@@ -243,7 +243,7 @@ action edit_credential($id, $issuer, $credential_type, $credential_level, $crede
 
 @kgw(authn='true')
 action remove_credential($id) public {
-    $converted = idos_eth.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     DELETE FROM credentials
     WHERE id=$id
     AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
@@ -253,7 +253,7 @@ action remove_credential($id) public {
 
 @kgw(authn='true')
 action get_credential_owned ($id) public view {
-    $converted = idos_eth.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT DISTINCT credentials.*
     FROM credentials
     INNER JOIN wallets ON credentials.human_id = wallets.human_id
@@ -280,7 +280,7 @@ action get_credential_shared ($id) public view {
 
 @kgw(authn='true')
 action share_attribute($id, $original_attribute_id, $attribute_key, $value) public {
-    $converted = idos_eth.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
     VALUES (
         $id,
@@ -306,7 +306,7 @@ action add_shared_attribute($original_id, $duplicate_id) owner public {
 
 @kgw(authn='true')
 action add_wallet($id, $address, $public_key, $message, $signature) public {
-    $converted = idos_near.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     $wallet_type = idos_near.determine_wallet_type($address);
     INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
     VALUES (
@@ -327,6 +327,6 @@ action add_wallet($id, $address, $public_key, $message, $signature) public {
 
 @kgw(authn='true')
 action show_caller() public view {
-    $converted = idos_eth.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT @caller, $converted;
 }

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -67,7 +67,7 @@ action add_human_as_owner($id) owner public {
 
 action upsert_wallet_as_owner($id, $human_id, $address, $public_key, $wallet_type, $message, $signature) owner public {
     SELECT CASE
-        WHEN $wallet_type = "NEAR" AND length($public_key) != 52
+        WHEN $wallet_type = 'NEAR' AND ($public_key IS NULL OR length($public_key) != 52)
         THEN ERROR('NEAR wallets require a valid public_key to be given.')
     END;
 
@@ -315,7 +315,7 @@ action add_wallet($id, $address, $public_key, $message, $signature) public {
     $wallet_type = idos_near.determine_wallet_type($address);
 
     SELECT CASE
-        WHEN $wallet_type = "NEAR" AND length($public_key) != 52
+        WHEN $wallet_type = 'NEAR' AND ($public_key IS NULL OR length($public_key) != 52)
         THEN ERROR('NEAR wallets require a valid public_key to be given.')
     END;
 

--- a/schema.playground.kf
+++ b/schema.playground.kf
@@ -91,26 +91,23 @@ action delete_human_as_owner($id) owner public { //for testing period, for not t
 @kgw(authn='true')
 action get_attributes() public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
 	SELECT DISTINCT ha.id, ha.human_id, ha.attribute_key, ha.value, sha.original_id AS original_id
     FROM human_attributes AS ha
     LEFT JOIN shared_human_attributes AS sha ON ha.id = sha.duplicate_id
-    INNER JOIN wallets ON ha.human_id = wallets.human_id
-    WHERE (
-        wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE
-    ) OR (
-        wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted
-    );
+    WHERE ha.human_id = $current_human_id;
 }
 
 @kgw(authn='true')
 action add_attribute($id, $attribute_key, $value) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
     VALUES (
         $id,
-        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-            OR (wallet_type = 'NEAR' AND public_key = $converted)
-        ),
+        $current_human_id,
         $attribute_key,
         $value
     );
@@ -129,44 +126,41 @@ action add_attribute_as_owner($id, $human_id, $attribute_key, $value) owner publ
 @kgw(authn='true')
 action edit_attribute($id, $attribute_key, $value) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
     UPDATE human_attributes
     SET attribute_key=$attribute_key, value=$value
     WHERE id=$id
-    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted)
-    );
+    AND human_id=$current_human_id;
 }
 
 @kgw(authn='true')
 action remove_attribute($id) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
     DELETE FROM human_attributes
     WHERE id=$id
-    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted)
-    );
+    AND human_id=$current_human_id;
 }
 
 @kgw(authn='true')
 action get_wallets() public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    SELECT DISTINCT w1.*
-    FROM wallets AS w1
-    INNER JOIN wallets AS w2 ON w1.human_id = w2.human_id
-    WHERE (
-        w2.wallet_type = 'EVM' AND w2.address = @caller COLLATE NOCASE
-    ) OR (
-        w2.wallet_type = 'NEAR' AND w2.public_key = $converted
-    );
+    $current_human_id = caller_human_id();
+
+    SELECT *
+    FROM wallets
+    WHERE human_id=$current_human_id;
 }
 
 @kgw(authn='true')
 action remove_wallet($id) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
     DELETE FROM wallets
-    WHERE id=$id AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted)
-    );
+    WHERE id=$id AND human_id=$current_human_id;
 }
 
 action has_profile($address) public view {
@@ -178,34 +172,31 @@ action has_profile($address) public view {
 @kgw(authn='true')
 action get_wallet_human_id() public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    SELECT DISTINCT human_id FROM wallets
-    WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted);
+    $current_human_id = caller_human_id();
+
+    SELECT $current_human_id as human_id;
 }
 
 @kgw(authn='true')
 action get_credentials() public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
 	SELECT DISTINCT c.id, c.human_id, c.issuer, c.credential_type, c.credential_level, c.credential_status, sc.original_id AS original_id
     FROM credentials AS c
     LEFT JOIN shared_credentials AS sc ON c.id = sc.duplicate_id
-    INNER JOIN wallets ON c.human_id = wallets.human_id
-    WHERE (
-        wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE
-    ) OR (
-        wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted
-    );
+    WHERE c.human_id = $current_human_id;
 }
 
 @kgw(authn='true')
 action add_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
     INSERT INTO credentials (id, human_id, issuer, credential_type, credential_level, credential_status, content, encryption_public_key)
     VALUES (
         $id,
-        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-            OR (wallet_type = 'NEAR' AND public_key = $converted)
-        ),
+        $current_human_id,
         $issuer,
         $credential_type,
         $credential_level,
@@ -218,12 +209,12 @@ action add_credential($id, $issuer, $credential_type, $credential_level, $creden
 @kgw(authn='true')
 action share_credential($id, $original_credential_id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
     INSERT INTO credentials (id, human_id, issuer, credential_type, credential_level, credential_status, content, encryption_public_key)
     VALUES (
         $id,
-        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-            OR (wallet_type = 'NEAR' AND public_key = $converted)
-        ),
+        $current_human_id,
         $issuer,
         $credential_type,
         $credential_level,
@@ -238,35 +229,33 @@ action share_credential($id, $original_credential_id, $issuer, $credential_type,
 @kgw(authn='true')
 action edit_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
     UPDATE credentials
     SET issuer=$issuer, credential_type=$credential_type, credential_level=$credential_level, credential_status=$credential_status, content=$content, encryption_public_key=$encryption_public_key
     WHERE id=$id
-    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted)
-    );
+    AND human_id=$current_human_id;
 }
 
 @kgw(authn='true')
 action remove_credential($id) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
     DELETE FROM credentials
     WHERE id=$id
-    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted)
-    );
+    AND human_id=$current_human_id;
 }
 
 @kgw(authn='true')
 action get_credential_owned ($id) public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
     SELECT DISTINCT credentials.*
     FROM credentials
-    INNER JOIN wallets ON credentials.human_id = wallets.human_id
     WHERE credentials.id = $id
-    AND (
-        (wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE)
-            OR (wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted)
-    );
+    AND credentials.human_id = $current_human_id;
 }
 
 @kgw(authn='true')
@@ -286,12 +275,12 @@ action get_credential_shared ($id) public view {
 @kgw(authn='true')
 action share_attribute($id, $original_attribute_id, $attribute_key, $value) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
     VALUES (
         $id,
-        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-            OR (wallet_type = 'NEAR' AND public_key = $converted)
-        ),
+        $current_human_id,
         $attribute_key,
         $value
     );
@@ -310,9 +299,10 @@ action add_shared_attribute($original_id, $duplicate_id) owner public {
 }
 
 @kgw(authn='true')
-action add_wallet($id, $address, $message, $signature) public {
+action add_wallet($id, $address, $public_key, $message, $signature) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     $wallet_type = idos_near.determine_wallet_type($address);
+    $current_human_id = caller_human_id();
 
     SELECT CASE
         WHEN $wallet_type = 'NEAR' AND ($public_key IS NULL OR length($public_key) != 52)
@@ -322,9 +312,7 @@ action add_wallet($id, $address, $message, $signature) public {
     INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
     VALUES (
         $id,
-        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-            OR (wallet_type = 'NEAR' AND public_key = $converted)
-        ),
+        $current_human_id,
         $address,
         CASE
             WHEN $public_key = '' THEN NULL
@@ -334,4 +322,14 @@ action add_wallet($id, $address, $message, $signature) public {
         $message,
         $signature
     );
+}
+
+action caller_human_id() private view {
+    $converted = idos_near.implicit_address_to_public_key(@caller);
+    SELECT human_id
+    FROM wallets
+    WHERE
+        (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
+    LIMIT 1;
 }

--- a/schema.playground.kf
+++ b/schema.playground.kf
@@ -33,7 +33,7 @@ table shared_human_attributes {
 table wallets {
     id text primary minlen(36) maxlen(36) notnull unique,
     human_id text minlen(36) maxlen(36) notnull,
-    address text,
+    address text notnull,
     public_key text,
     wallet_type text notnull,
     message text,

--- a/schema.playground.kf
+++ b/schema.playground.kf
@@ -66,10 +66,10 @@ action add_human_as_owner($id) owner public {
 }
 
 action upsert_wallet_as_owner($id, $human_id, $address, $public_key, $wallet_type, $message, $signature) owner public {
-    SELECT CASE
-        WHEN $wallet_type = 'NEAR' AND ($public_key IS NULL OR length($public_key) != 52)
-        THEN ERROR('NEAR wallets require a valid public_key to be given.')
-    END;
+    SELECT CASE WHEN $wallet_type = 'NEAR' AND $public_key IS NULL THEN ERROR('NEAR wallets require a public_key to be given.') END;
+
+    $valid_near_public_key = idos_near.is_valid_public_key($public_key);
+    SELECT CASE WHEN $wallet_type = 'NEAR' AND $valid_near_public_key != 1 THEN ERROR('Invalid or unsupported public key.') END;
 
     INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
     VALUES ($id, $human_id, $address, $public_key, $wallet_type, $message, $signature)
@@ -318,10 +318,10 @@ action add_wallet($id, $address, $public_key, $message, $signature) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     $wallet_type = idos_near.determine_wallet_type($address);
 
-    SELECT CASE
-        WHEN $wallet_type = 'NEAR' AND ($public_key IS NULL OR length($public_key) != 52)
-        THEN ERROR('NEAR wallets require a valid public_key to be given.')
-    END;
+    SELECT CASE WHEN $wallet_type = 'NEAR' AND $public_key IS NULL THEN ERROR('NEAR wallets require a public_key to be given.') END;
+
+    $valid_near_public_key = idos_near.is_valid_public_key($public_key);
+    SELECT CASE WHEN $wallet_type = 'NEAR' AND $valid_near_public_key != 1 THEN ERROR('Invalid or unsupported public key.') END;
 
     INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
     VALUES (

--- a/schema.playground.kf
+++ b/schema.playground.kf
@@ -33,8 +33,9 @@ table shared_human_attributes {
 table wallets {
     id text primary minlen(36) maxlen(36) notnull unique,
     human_id text minlen(36) maxlen(36) notnull,
-    address text notnull,
-    public_key text notnull,
+    address text,
+    public_key text,
+    wallet_type text notnull,
     message text,
     signature text,
     foreign_key (human_id) references humans(id) on_delete cascade
@@ -60,13 +61,13 @@ table shared_credentials {
     foreign_key (duplicate_id) references credentials(id) on_delete cascade
 }
 
-action add_human_as_owner($id) public { // this is temporary for easy adding users not through nautilus for test purposes
+action add_human_as_owner($id) owner public { // this is temporary for easy adding users not through nautilus for test purposes
     INSERT INTO humans (id) VALUES ($id);
 }
 
-action upsert_wallet_as_owner($id, $human_id, $address, $public_key, $message, $signature) owner public {
-    INSERT INTO wallets (id, human_id, address, public_key, message, signature)
-    VALUES ($id, $human_id, $address, $public_key, $message, $signature)
+action upsert_wallet_as_owner($id, $human_id, $address, $public_key, $wallet_type, $message, $signature) owner public {
+    INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
+    VALUES ($id, $human_id, $address, $public_key, $wallet_type, $message, $signature)
     ON CONFLICT(id) DO UPDATE
     SET human_id=$human_id, address=$address, public_key=$public_key, message=$message, signature=$signature;
 }
@@ -82,19 +83,29 @@ action delete_human_as_owner($id) owner public { //for testing period, for not t
     DELETE FROM humans WHERE id=$id;
 }
 
-action get_attributes() public view mustsign {
+@kgw(authn='true')
+action get_attributes() public view {
+    $converted = idos_near.hex_to_base58(@caller);
 	SELECT DISTINCT ha.id, ha.human_id, ha.attribute_key, ha.value, sha.original_id AS original_id
     FROM human_attributes AS ha
     LEFT JOIN shared_human_attributes AS sha ON ha.id = sha.duplicate_id
     INNER JOIN wallets ON ha.human_id = wallets.human_id
-    WHERE wallets.address = address(@caller) COLLATE NOCASE OR wallets.public_key = public_key(@caller, 'base64') COLLATE NOCASE;
+    WHERE (
+        wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE
+    ) OR (
+        wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted
+    );
 }
 
-action add_attribute($id, $attribute_key, $value) public mustsign {
+@kgw(authn='true')
+action add_attribute($id, $attribute_key, $value) public {
+    $converted = idos_near.hex_to_base58(@caller);
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
     VALUES (
         $id,
-        (SELECT DISTINCT human_id FROM wallets WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE),
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = $converted)
+        ),
         $attribute_key,
         $value
     );
@@ -110,41 +121,47 @@ action add_attribute_as_owner($id, $human_id, $attribute_key, $value) owner publ
     );
 }
 
-action edit_attribute($id, $attribute_key, $value) public mustsign {
+@kgw(authn='true')
+action edit_attribute($id, $attribute_key, $value) public {
+    $converted = idos_near.hex_to_base58(@caller);
     UPDATE human_attributes
     SET attribute_key=$attribute_key, value=$value
     WHERE id=$id
-    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE);
-}
-
-action remove_attribute($id) public mustsign {
-    DELETE FROM human_attributes
-    WHERE id=$id
-    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE);
-}
-
-action get_wallets() public view mustsign {
-    SELECT DISTINCT w1.*
-    FROM wallets AS w1
-    INNER JOIN wallets AS w2 ON w1.human_id = w2.human_id
-    WHERE w2.address = address(@caller) COLLATE NOCASE OR w2.public_key = public_key(@caller, 'base64') COLLATE NOCASE;
-}
-
-action add_wallet($id, $address, $message, $signature) public mustsign {
-    INSERT INTO wallets (id, human_id, address, public_key, message, signature)
-    VALUES (
-        $id,
-        (SELECT DISTINCT human_id FROM wallets WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE),
-        $address,
-        public_key(@caller, 'base64'),
-        $message,
-        $signature
+    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
     );
 }
 
-action remove_wallet($id) public mustsign {
+@kgw(authn='true')
+action remove_attribute($id) public {
+    $converted = idos_near.hex_to_base58(@caller);
+    DELETE FROM human_attributes
+    WHERE id=$id
+    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
+    );
+}
+
+@kgw(authn='true')
+action get_wallets() public view {
+    $converted = idos_near.hex_to_base58(@caller);
+    SELECT DISTINCT w1.*
+    FROM wallets AS w1
+    INNER JOIN wallets AS w2 ON w1.human_id = w2.human_id
+    WHERE (
+        w2.wallet_type = 'EVM' AND w2.address = @caller COLLATE NOCASE
+    ) OR (
+        w2.wallet_type = 'NEAR' AND w2.public_key = $converted
+    );
+}
+
+@kgw(authn='true')
+action remove_wallet($id) public {
+    $converted = idos_eth.hex_to_base58(@caller);
     DELETE FROM wallets
-    WHERE id=$id AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE);
+    WHERE id=$id AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
+    );
 }
 
 action has_profile($address) public view {
@@ -153,23 +170,37 @@ action has_profile($address) public view {
     ) AS has_profile;
 }
 
-action get_wallet_human_id() public view mustsign {
+@kgw(authn='true')
+action get_wallet_human_id() public view {
+    $converted = idos_eth.hex_to_base58(@caller);
     SELECT DISTINCT human_id FROM wallets
-    WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE;
+    WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted);
 }
-action get_credentials() public view mustsign {
+
+@kgw(authn='true')
+action get_credentials() public view {
+    $converted = idos_eth.hex_to_base58(@caller);
 	SELECT DISTINCT c.id, c.human_id, c.issuer, c.credential_type, c.credential_level, c.credential_status, sc.original_id AS original_id
     FROM credentials AS c
     LEFT JOIN shared_credentials AS sc ON c.id = sc.duplicate_id
     INNER JOIN wallets ON c.human_id = wallets.human_id
-    WHERE wallets.address = address(@caller) COLLATE NOCASE OR wallets.public_key = public_key(@caller, 'base64') COLLATE NOCASE;
+    WHERE (
+        wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE
+    ) OR (
+        wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted
+    );
 }
 
-action add_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public mustsign {
+@kgw(authn='true')
+action add_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
+    $converted = idos_eth.hex_to_base58(@caller);
     INSERT INTO credentials (id, human_id, issuer, credential_type, credential_level, credential_status, content, encryption_public_key)
     VALUES (
         $id,
-        (SELECT DISTINCT human_id from wallets WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE),
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = $converted)
+        ),
         $issuer,
         $credential_type,
         $credential_level,
@@ -179,11 +210,15 @@ action add_credential($id, $issuer, $credential_type, $credential_level, $creden
     );
 }
 
-action share_credential($id, $original_credential_id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public mustsign {
+@kgw(authn='true')
+action share_credential($id, $original_credential_id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
+    $converted = idos_eth.hex_to_base58(@caller);
     INSERT INTO credentials (id, human_id, issuer, credential_type, credential_level, credential_status, content, encryption_public_key)
     VALUES (
         $id,
-        (SELECT DISTINCT human_id from wallets WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE),
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = $converted)
+        ),
         $issuer,
         $credential_type,
         $credential_level,
@@ -195,30 +230,44 @@ action share_credential($id, $original_credential_id, $issuer, $credential_type,
     add_shared_credential($original_credential_id, $id);
 }
 
-action edit_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public mustsign {
+@kgw(authn='true')
+action edit_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
+    $converted = idos_eth.hex_to_base58(@caller);
     UPDATE credentials
     SET issuer=$issuer, credential_type=$credential_type, credential_level=$credential_level, credential_status=$credential_status, content=$content, encryption_public_key=$encryption_public_key
     WHERE id=$id
-    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE);
+    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
+    );
 }
 
-action remove_credential($id) public mustsign {
+@kgw(authn='true')
+action remove_credential($id) public {
+    $converted = idos_eth.hex_to_base58(@caller);
     DELETE FROM credentials
     WHERE id=$id
-    AND human_id=(SELECT human_id FROM wallets WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE);
+    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
+    );
 }
 
-action get_credential_owned ($id) public view mustsign {
+@kgw(authn='true')
+action get_credential_owned ($id) public view {
+    $converted = idos_eth.hex_to_base58(@caller);
     SELECT DISTINCT credentials.*
     FROM credentials
     INNER JOIN wallets ON credentials.human_id = wallets.human_id
     WHERE credentials.id = $id
-    AND (wallets.address = address(@caller) COLLATE NOCASE OR wallets.public_key = public_key(@caller, 'base64') COLLATE NOCASE);
+    AND (
+        (wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE)
+            OR (wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted)
+    );
 }
 
-action get_credential_shared ($id) public view mustsign {
-    $has_grant_on_eth = idos_eth.has_grants(address(@caller), $id);
-    $has_grant_on_near = idos_near.has_grants(address(@caller), $id);
+@kgw(authn='true')
+action get_credential_shared ($id) public view {
+    $has_grant_on_eth = idos_eth.has_grants(@caller, $id);
+    $has_grant_on_near = idos_near.has_grants(@caller, $id);
 
     SELECT CASE
         WHEN $has_grant_on_eth != 1 AND $has_grant_on_near != 1
@@ -229,11 +278,15 @@ action get_credential_shared ($id) public view mustsign {
     WHERE id = $id;
 }
 
-action share_attribute($id, $original_attribute_id, $attribute_key, $value) public mustsign {
+@kgw(authn='true')
+action share_attribute($id, $original_attribute_id, $attribute_key, $value) public {
+    $converted = idos_eth.hex_to_base58(@caller);
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
     VALUES (
         $id,
-        (SELECT DISTINCT human_id from wallets WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE),
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = $converted)
+        ),
         $attribute_key,
         $value
     );
@@ -249,4 +302,22 @@ action add_shared_credential($original_id, $duplicate_id) owner public {
 action add_shared_attribute($original_id, $duplicate_id) owner public {
     INSERT INTO shared_human_attributes (original_id, duplicate_id)
     VALUES ($original_id, $duplicate_id);
+}
+
+@kgw(authn='true')
+action add_wallet($id, $address, $message, $signature) public {
+    $converted = idos_near.hex_to_base58(@caller);
+    $wallet_type = idos_near.determine_wallet_type($address);
+    INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
+    VALUES (
+        $id,
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = $converted)
+        ),
+        $address,
+        NULL,
+        $wallet_type,
+        $message,
+        $signature
+    );
 }

--- a/schema.playground.kf
+++ b/schema.playground.kf
@@ -88,6 +88,10 @@ action delete_human_as_owner($id) owner public { //for testing period, for not t
     DELETE FROM humans WHERE id=$id;
 }
 
+action delete_wallet_as_owner($id) owner public { //temporary, to remove wrong data from initial test period
+    DELETE FROM wallets WHERE id=$id;
+}
+
 @kgw(authn='true')
 action get_attributes() public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);

--- a/schema.playground.kf
+++ b/schema.playground.kf
@@ -61,7 +61,7 @@ table shared_credentials {
     foreign_key (duplicate_id) references credentials(id) on_delete cascade
 }
 
-action add_human_as_owner($id) owner public { // this is temporary for easy adding users not through nautilus for test purposes
+action add_human_as_owner($id) owner public {
     INSERT INTO humans (id) VALUES ($id);
 }
 

--- a/schema.playground.kf
+++ b/schema.playground.kf
@@ -95,23 +95,26 @@ action delete_wallet_as_owner($id) owner public { //temporary, to remove wrong d
 @kgw(authn='true')
 action get_attributes() public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
 	SELECT DISTINCT ha.id, ha.human_id, ha.attribute_key, ha.value, sha.original_id AS original_id
     FROM human_attributes AS ha
     LEFT JOIN shared_human_attributes AS sha ON ha.id = sha.duplicate_id
-    WHERE ha.human_id = $current_human_id;
+    INNER JOIN wallets ON ha.human_id = wallets.human_id
+    WHERE (
+        wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE
+    ) OR (
+        wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted
+    );
 }
 
 @kgw(authn='true')
 action add_attribute($id, $attribute_key, $value) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
     VALUES (
         $id,
-        $current_human_id,
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = $converted)
+        ),
         $attribute_key,
         $value
     );
@@ -130,41 +133,44 @@ action add_attribute_as_owner($id, $human_id, $attribute_key, $value) owner publ
 @kgw(authn='true')
 action edit_attribute($id, $attribute_key, $value) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
     UPDATE human_attributes
     SET attribute_key=$attribute_key, value=$value
     WHERE id=$id
-    AND human_id=$current_human_id;
+    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
+    );
 }
 
 @kgw(authn='true')
 action remove_attribute($id) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
     DELETE FROM human_attributes
     WHERE id=$id
-    AND human_id=$current_human_id;
+    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
+    );
 }
 
 @kgw(authn='true')
 action get_wallets() public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
-    SELECT *
-    FROM wallets
-    WHERE human_id=$current_human_id;
+    SELECT DISTINCT w1.*
+    FROM wallets AS w1
+    INNER JOIN wallets AS w2 ON w1.human_id = w2.human_id
+    WHERE (
+        w2.wallet_type = 'EVM' AND w2.address = @caller COLLATE NOCASE
+    ) OR (
+        w2.wallet_type = 'NEAR' AND w2.public_key = $converted
+    );
 }
 
 @kgw(authn='true')
 action remove_wallet($id) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
     DELETE FROM wallets
-    WHERE id=$id AND human_id=$current_human_id;
+    WHERE id=$id AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
+    );
 }
 
 action has_profile($address) public view {
@@ -176,31 +182,34 @@ action has_profile($address) public view {
 @kgw(authn='true')
 action get_wallet_human_id() public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
-    SELECT $current_human_id as human_id;
+    SELECT DISTINCT human_id FROM wallets
+    WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted);
 }
 
 @kgw(authn='true')
 action get_credentials() public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
 	SELECT DISTINCT c.id, c.human_id, c.issuer, c.credential_type, c.credential_level, c.credential_status, sc.original_id AS original_id
     FROM credentials AS c
     LEFT JOIN shared_credentials AS sc ON c.id = sc.duplicate_id
-    WHERE c.human_id = $current_human_id;
+    INNER JOIN wallets ON c.human_id = wallets.human_id
+    WHERE (
+        wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE
+    ) OR (
+        wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted
+    );
 }
 
 @kgw(authn='true')
 action add_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
     INSERT INTO credentials (id, human_id, issuer, credential_type, credential_level, credential_status, content, encryption_public_key)
     VALUES (
         $id,
-        $current_human_id,
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = $converted)
+        ),
         $issuer,
         $credential_type,
         $credential_level,
@@ -213,12 +222,12 @@ action add_credential($id, $issuer, $credential_type, $credential_level, $creden
 @kgw(authn='true')
 action share_credential($id, $original_credential_id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
     INSERT INTO credentials (id, human_id, issuer, credential_type, credential_level, credential_status, content, encryption_public_key)
     VALUES (
         $id,
-        $current_human_id,
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = $converted)
+        ),
         $issuer,
         $credential_type,
         $credential_level,
@@ -233,33 +242,35 @@ action share_credential($id, $original_credential_id, $issuer, $credential_type,
 @kgw(authn='true')
 action edit_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
     UPDATE credentials
     SET issuer=$issuer, credential_type=$credential_type, credential_level=$credential_level, credential_status=$credential_status, content=$content, encryption_public_key=$encryption_public_key
     WHERE id=$id
-    AND human_id=$current_human_id;
+    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
+    );
 }
 
 @kgw(authn='true')
 action remove_credential($id) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
     DELETE FROM credentials
     WHERE id=$id
-    AND human_id=$current_human_id;
+    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
+    );
 }
 
 @kgw(authn='true')
 action get_credential_owned ($id) public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
     SELECT DISTINCT credentials.*
     FROM credentials
+    INNER JOIN wallets ON credentials.human_id = wallets.human_id
     WHERE credentials.id = $id
-    AND credentials.human_id = $current_human_id;
+    AND (
+        (wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE)
+            OR (wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted)
+    );
 }
 
 @kgw(authn='true')
@@ -279,12 +290,12 @@ action get_credential_shared ($id) public view {
 @kgw(authn='true')
 action share_attribute($id, $original_attribute_id, $attribute_key, $value) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
     VALUES (
         $id,
-        $current_human_id,
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = $converted)
+        ),
         $attribute_key,
         $value
     );
@@ -303,10 +314,9 @@ action add_shared_attribute($original_id, $duplicate_id) owner public {
 }
 
 @kgw(authn='true')
-action add_wallet($id, $address, $public_key, $message, $signature) public {
+action add_wallet($id, $address, $message, $signature) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     $wallet_type = idos_near.determine_wallet_type($address);
-    $current_human_id = caller_human_id();
 
     SELECT CASE
         WHEN $wallet_type = 'NEAR' AND ($public_key IS NULL OR length($public_key) != 52)
@@ -316,7 +326,9 @@ action add_wallet($id, $address, $public_key, $message, $signature) public {
     INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
     VALUES (
         $id,
-        $current_human_id,
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = $converted)
+        ),
         $address,
         CASE
             WHEN $public_key = '' THEN NULL
@@ -326,14 +338,4 @@ action add_wallet($id, $address, $public_key, $message, $signature) public {
         $message,
         $signature
     );
-}
-
-action caller_human_id() private view {
-    $converted = idos_near.implicit_address_to_public_key(@caller);
-    SELECT human_id
-    FROM wallets
-    WHERE
-        (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted)
-    LIMIT 1;
 }

--- a/schema.playground.kf
+++ b/schema.playground.kf
@@ -326,7 +326,10 @@ action add_wallet($id, $address, $message, $signature) public {
             OR (wallet_type = 'NEAR' AND public_key = $converted)
         ),
         $address,
-        NULL,
+        CASE
+            WHEN $public_key = '' THEN NULL
+            ELSE $public_key
+        END,
         $wallet_type,
         $message,
         $signature

--- a/schema.playground.kf
+++ b/schema.playground.kf
@@ -85,7 +85,7 @@ action delete_human_as_owner($id) owner public { //for testing period, for not t
 
 @kgw(authn='true')
 action get_attributes() public view {
-    $converted = idos_near.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
 	SELECT DISTINCT ha.id, ha.human_id, ha.attribute_key, ha.value, sha.original_id AS original_id
     FROM human_attributes AS ha
     LEFT JOIN shared_human_attributes AS sha ON ha.id = sha.duplicate_id
@@ -99,7 +99,7 @@ action get_attributes() public view {
 
 @kgw(authn='true')
 action add_attribute($id, $attribute_key, $value) public {
-    $converted = idos_near.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
     VALUES (
         $id,
@@ -123,7 +123,7 @@ action add_attribute_as_owner($id, $human_id, $attribute_key, $value) owner publ
 
 @kgw(authn='true')
 action edit_attribute($id, $attribute_key, $value) public {
-    $converted = idos_near.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     UPDATE human_attributes
     SET attribute_key=$attribute_key, value=$value
     WHERE id=$id
@@ -134,7 +134,7 @@ action edit_attribute($id, $attribute_key, $value) public {
 
 @kgw(authn='true')
 action remove_attribute($id) public {
-    $converted = idos_near.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     DELETE FROM human_attributes
     WHERE id=$id
     AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
@@ -144,7 +144,7 @@ action remove_attribute($id) public {
 
 @kgw(authn='true')
 action get_wallets() public view {
-    $converted = idos_near.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT DISTINCT w1.*
     FROM wallets AS w1
     INNER JOIN wallets AS w2 ON w1.human_id = w2.human_id
@@ -157,7 +157,7 @@ action get_wallets() public view {
 
 @kgw(authn='true')
 action remove_wallet($id) public {
-    $converted = idos_eth.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     DELETE FROM wallets
     WHERE id=$id AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
         OR (wallet_type = 'NEAR' AND public_key = $converted)
@@ -172,7 +172,7 @@ action has_profile($address) public view {
 
 @kgw(authn='true')
 action get_wallet_human_id() public view {
-    $converted = idos_eth.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT DISTINCT human_id FROM wallets
     WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
         OR (wallet_type = 'NEAR' AND public_key = $converted);
@@ -180,7 +180,7 @@ action get_wallet_human_id() public view {
 
 @kgw(authn='true')
 action get_credentials() public view {
-    $converted = idos_eth.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
 	SELECT DISTINCT c.id, c.human_id, c.issuer, c.credential_type, c.credential_level, c.credential_status, sc.original_id AS original_id
     FROM credentials AS c
     LEFT JOIN shared_credentials AS sc ON c.id = sc.duplicate_id
@@ -194,7 +194,7 @@ action get_credentials() public view {
 
 @kgw(authn='true')
 action add_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
-    $converted = idos_eth.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     INSERT INTO credentials (id, human_id, issuer, credential_type, credential_level, credential_status, content, encryption_public_key)
     VALUES (
         $id,
@@ -212,7 +212,7 @@ action add_credential($id, $issuer, $credential_type, $credential_level, $creden
 
 @kgw(authn='true')
 action share_credential($id, $original_credential_id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
-    $converted = idos_eth.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     INSERT INTO credentials (id, human_id, issuer, credential_type, credential_level, credential_status, content, encryption_public_key)
     VALUES (
         $id,
@@ -232,7 +232,7 @@ action share_credential($id, $original_credential_id, $issuer, $credential_type,
 
 @kgw(authn='true')
 action edit_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
-    $converted = idos_eth.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     UPDATE credentials
     SET issuer=$issuer, credential_type=$credential_type, credential_level=$credential_level, credential_status=$credential_status, content=$content, encryption_public_key=$encryption_public_key
     WHERE id=$id
@@ -243,7 +243,7 @@ action edit_credential($id, $issuer, $credential_type, $credential_level, $crede
 
 @kgw(authn='true')
 action remove_credential($id) public {
-    $converted = idos_eth.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     DELETE FROM credentials
     WHERE id=$id
     AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
@@ -253,7 +253,7 @@ action remove_credential($id) public {
 
 @kgw(authn='true')
 action get_credential_owned ($id) public view {
-    $converted = idos_eth.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT DISTINCT credentials.*
     FROM credentials
     INNER JOIN wallets ON credentials.human_id = wallets.human_id
@@ -280,7 +280,7 @@ action get_credential_shared ($id) public view {
 
 @kgw(authn='true')
 action share_attribute($id, $original_attribute_id, $attribute_key, $value) public {
-    $converted = idos_eth.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
     VALUES (
         $id,
@@ -306,7 +306,7 @@ action add_shared_attribute($original_id, $duplicate_id) owner public {
 
 @kgw(authn='true')
 action add_wallet($id, $address, $message, $signature) public {
-    $converted = idos_near.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     $wallet_type = idos_near.determine_wallet_type($address);
     INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
     VALUES (

--- a/schema.playground.kf
+++ b/schema.playground.kf
@@ -67,7 +67,7 @@ action add_human_as_owner($id) owner public {
 
 action upsert_wallet_as_owner($id, $human_id, $address, $public_key, $wallet_type, $message, $signature) owner public {
     SELECT CASE
-        WHEN $wallet_type = "NEAR" AND length($public_key) != 52
+        WHEN $wallet_type = 'NEAR' AND ($public_key IS NULL OR length($public_key) != 52)
         THEN ERROR('NEAR wallets require a valid public_key to be given.')
     END;
 
@@ -315,7 +315,7 @@ action add_wallet($id, $address, $message, $signature) public {
     $wallet_type = idos_near.determine_wallet_type($address);
 
     SELECT CASE
-        WHEN $wallet_type = "NEAR" AND length($public_key) != 52
+        WHEN $wallet_type = 'NEAR' AND ($public_key IS NULL OR length($public_key) != 52)
         THEN ERROR('NEAR wallets require a valid public_key to be given.')
     END;
 

--- a/schema.playground.kf
+++ b/schema.playground.kf
@@ -74,7 +74,7 @@ action upsert_wallet_as_owner($id, $human_id, $address, $public_key, $wallet_typ
     INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
     VALUES ($id, $human_id, $address, $public_key, $wallet_type, $message, $signature)
     ON CONFLICT(id) DO UPDATE
-    SET human_id=$human_id, address=$address, public_key=$public_key, message=$message, signature=$signature;
+    SET human_id=$human_id, address=$address, public_key=$public_key, wallet_type=$wallet_type, message=$message, signature=$signature;
 }
 
 action upsert_credential_as_owner($id, $human_id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) owner public {
@@ -314,7 +314,7 @@ action add_shared_attribute($original_id, $duplicate_id) owner public {
 }
 
 @kgw(authn='true')
-action add_wallet($id, $address, $message, $signature) public {
+action add_wallet($id, $address, $public_key, $message, $signature) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     $wallet_type = idos_near.determine_wallet_type($address);
 

--- a/schema.playground.kf
+++ b/schema.playground.kf
@@ -66,6 +66,11 @@ action add_human_as_owner($id) owner public {
 }
 
 action upsert_wallet_as_owner($id, $human_id, $address, $public_key, $wallet_type, $message, $signature) owner public {
+    SELECT CASE
+        WHEN $wallet_type = "NEAR" AND length($public_key) != 52
+        THEN ERROR('NEAR wallets require a valid public_key to be given.')
+    END;
+
     INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
     VALUES ($id, $human_id, $address, $public_key, $wallet_type, $message, $signature)
     ON CONFLICT(id) DO UPDATE
@@ -308,6 +313,12 @@ action add_shared_attribute($original_id, $duplicate_id) owner public {
 action add_wallet($id, $address, $message, $signature) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     $wallet_type = idos_near.determine_wallet_type($address);
+
+    SELECT CASE
+        WHEN $wallet_type = "NEAR" AND length($public_key) != 52
+        THEN ERROR('NEAR wallets require a valid public_key to be given.')
+    END;
+
     INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
     VALUES (
         $id,

--- a/schema.production.kf
+++ b/schema.production.kf
@@ -91,26 +91,23 @@ action delete_human_as_owner($id) owner public { //for testing period, for not t
 @kgw(authn='true')
 action get_attributes() public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
 	SELECT DISTINCT ha.id, ha.human_id, ha.attribute_key, ha.value, sha.original_id AS original_id
     FROM human_attributes AS ha
     LEFT JOIN shared_human_attributes AS sha ON ha.id = sha.duplicate_id
-    INNER JOIN wallets ON ha.human_id = wallets.human_id
-    WHERE (
-        wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE
-    ) OR (
-        wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted
-    );
+    WHERE ha.human_id = $current_human_id;
 }
 
 @kgw(authn='true')
 action add_attribute($id, $attribute_key, $value) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
     VALUES (
         $id,
-        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-            OR (wallet_type = 'NEAR' AND public_key = $converted)
-        ),
+        $current_human_id,
         $attribute_key,
         $value
     );
@@ -129,44 +126,41 @@ action add_attribute_as_owner($id, $human_id, $attribute_key, $value) owner publ
 @kgw(authn='true')
 action edit_attribute($id, $attribute_key, $value) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
     UPDATE human_attributes
     SET attribute_key=$attribute_key, value=$value
     WHERE id=$id
-    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted)
-    );
+    AND human_id=$current_human_id;
 }
 
 @kgw(authn='true')
 action remove_attribute($id) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
     DELETE FROM human_attributes
     WHERE id=$id
-    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted)
-    );
+    AND human_id=$current_human_id;
 }
 
 @kgw(authn='true')
 action get_wallets() public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    SELECT DISTINCT w1.*
-    FROM wallets AS w1
-    INNER JOIN wallets AS w2 ON w1.human_id = w2.human_id
-    WHERE (
-        w2.wallet_type = 'EVM' AND w2.address = @caller COLLATE NOCASE
-    ) OR (
-        w2.wallet_type = 'NEAR' AND w2.public_key = $converted
-    );
+    $current_human_id = caller_human_id();
+
+    SELECT *
+    FROM wallets
+    WHERE human_id=$current_human_id;
 }
 
 @kgw(authn='true')
 action remove_wallet($id) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
     DELETE FROM wallets
-    WHERE id=$id AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted)
-    );
+    WHERE id=$id AND human_id=$current_human_id;
 }
 
 action has_profile($address) public view {
@@ -178,34 +172,31 @@ action has_profile($address) public view {
 @kgw(authn='true')
 action get_wallet_human_id() public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    SELECT DISTINCT human_id FROM wallets
-    WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted);
+    $current_human_id = caller_human_id();
+
+    SELECT $current_human_id as human_id;
 }
 
 @kgw(authn='true')
 action get_credentials() public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
 	SELECT DISTINCT c.id, c.human_id, c.issuer, c.credential_type, c.credential_level, c.credential_status, sc.original_id AS original_id
     FROM credentials AS c
     LEFT JOIN shared_credentials AS sc ON c.id = sc.duplicate_id
-    INNER JOIN wallets ON c.human_id = wallets.human_id
-    WHERE (
-        wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE
-    ) OR (
-        wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted
-    );
+    WHERE c.human_id = $current_human_id;
 }
 
 @kgw(authn='true')
 action add_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
     INSERT INTO credentials (id, human_id, issuer, credential_type, credential_level, credential_status, content, encryption_public_key)
     VALUES (
         $id,
-        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-            OR (wallet_type = 'NEAR' AND public_key = $converted)
-        ),
+        $current_human_id,
         $issuer,
         $credential_type,
         $credential_level,
@@ -218,12 +209,12 @@ action add_credential($id, $issuer, $credential_type, $credential_level, $creden
 @kgw(authn='true')
 action share_credential($id, $original_credential_id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
     INSERT INTO credentials (id, human_id, issuer, credential_type, credential_level, credential_status, content, encryption_public_key)
     VALUES (
         $id,
-        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-            OR (wallet_type = 'NEAR' AND public_key = $converted)
-        ),
+        $current_human_id,
         $issuer,
         $credential_type,
         $credential_level,
@@ -238,35 +229,33 @@ action share_credential($id, $original_credential_id, $issuer, $credential_type,
 @kgw(authn='true')
 action edit_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
     UPDATE credentials
     SET issuer=$issuer, credential_type=$credential_type, credential_level=$credential_level, credential_status=$credential_status, content=$content, encryption_public_key=$encryption_public_key
     WHERE id=$id
-    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted)
-    );
+    AND human_id=$current_human_id;
 }
 
 @kgw(authn='true')
 action remove_credential($id) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
     DELETE FROM credentials
     WHERE id=$id
-    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted)
-    );
+    AND human_id=$current_human_id;
 }
 
 @kgw(authn='true')
 action get_credential_owned ($id) public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
     SELECT DISTINCT credentials.*
     FROM credentials
-    INNER JOIN wallets ON credentials.human_id = wallets.human_id
     WHERE credentials.id = $id
-    AND (
-        (wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE)
-            OR (wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted)
-    );
+    AND credentials.human_id = $current_human_id;
 }
 
 @kgw(authn='true')
@@ -286,12 +275,12 @@ action get_credential_shared ($id) public view {
 @kgw(authn='true')
 action share_attribute($id, $original_attribute_id, $attribute_key, $value) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
     VALUES (
         $id,
-        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-            OR (wallet_type = 'NEAR' AND public_key = $converted)
-        ),
+        $current_human_id,
         $attribute_key,
         $value
     );
@@ -310,9 +299,10 @@ action add_shared_attribute($original_id, $duplicate_id) owner public {
 }
 
 @kgw(authn='true')
-action add_wallet($id, $address, $message, $signature) public {
+action add_wallet($id, $address, $public_key, $message, $signature) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     $wallet_type = idos_near.determine_wallet_type($address);
+    $current_human_id = caller_human_id();
 
     SELECT CASE
         WHEN $wallet_type = 'NEAR' AND ($public_key IS NULL OR length($public_key) != 52)
@@ -322,9 +312,7 @@ action add_wallet($id, $address, $message, $signature) public {
     INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
     VALUES (
         $id,
-        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-            OR (wallet_type = 'NEAR' AND public_key = $converted)
-        ),
+        $current_human_id,
         $address,
         CASE
             WHEN $public_key = '' THEN NULL
@@ -334,4 +322,14 @@ action add_wallet($id, $address, $message, $signature) public {
         $message,
         $signature
     );
+}
+
+action caller_human_id() private view {
+    $converted = idos_near.implicit_address_to_public_key(@caller);
+    SELECT human_id
+    FROM wallets
+    WHERE
+        (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
+    LIMIT 1;
 }

--- a/schema.production.kf
+++ b/schema.production.kf
@@ -33,7 +33,7 @@ table shared_human_attributes {
 table wallets {
     id text primary minlen(36) maxlen(36) notnull unique,
     human_id text minlen(36) maxlen(36) notnull,
-    address text,
+    address text notnull,
     public_key text,
     wallet_type text notnull,
     message text,

--- a/schema.production.kf
+++ b/schema.production.kf
@@ -66,10 +66,10 @@ action add_human_as_owner($id) owner public {
 }
 
 action upsert_wallet_as_owner($id, $human_id, $address, $public_key, $wallet_type, $message, $signature) owner public {
-    SELECT CASE
-        WHEN $wallet_type = 'NEAR' AND ($public_key IS NULL OR length($public_key) != 52)
-        THEN ERROR('NEAR wallets require a valid public_key to be given.')
-    END;
+    SELECT CASE WHEN $wallet_type = 'NEAR' AND $public_key IS NULL THEN ERROR('NEAR wallets require a public_key to be given.') END;
+
+    $valid_near_public_key = idos_near.is_valid_public_key($public_key);
+    SELECT CASE WHEN $wallet_type = 'NEAR' AND $valid_near_public_key != 1 THEN ERROR('Invalid or unsupported public key.') END;
 
     INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
     VALUES ($id, $human_id, $address, $public_key, $wallet_type, $message, $signature)
@@ -318,10 +318,10 @@ action add_wallet($id, $address, $public_key, $message, $signature) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     $wallet_type = idos_near.determine_wallet_type($address);
 
-    SELECT CASE
-        WHEN $wallet_type = 'NEAR' AND ($public_key IS NULL OR length($public_key) != 52)
-        THEN ERROR('NEAR wallets require a valid public_key to be given.')
-    END;
+    SELECT CASE WHEN $wallet_type = 'NEAR' AND $public_key IS NULL THEN ERROR('NEAR wallets require a public_key to be given.') END;
+
+    $valid_near_public_key = idos_near.is_valid_public_key($public_key);
+    SELECT CASE WHEN $wallet_type = 'NEAR' AND $valid_near_public_key != 1 THEN ERROR('Invalid or unsupported public key.') END;
 
     INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
     VALUES (

--- a/schema.production.kf
+++ b/schema.production.kf
@@ -33,8 +33,9 @@ table shared_human_attributes {
 table wallets {
     id text primary minlen(36) maxlen(36) notnull unique,
     human_id text minlen(36) maxlen(36) notnull,
-    address text notnull,
-    public_key text notnull,
+    address text,
+    public_key text,
+    wallet_type text notnull,
     message text,
     signature text,
     foreign_key (human_id) references humans(id) on_delete cascade
@@ -60,13 +61,13 @@ table shared_credentials {
     foreign_key (duplicate_id) references credentials(id) on_delete cascade
 }
 
-action add_human_as_owner($id) public { // this is temporary for easy adding users not through nautilus for test purposes
+action add_human_as_owner($id) owner public { // this is temporary for easy adding users not through nautilus for test purposes
     INSERT INTO humans (id) VALUES ($id);
 }
 
-action upsert_wallet_as_owner($id, $human_id, $address, $public_key, $message, $signature) owner public {
-    INSERT INTO wallets (id, human_id, address, public_key, message, signature)
-    VALUES ($id, $human_id, $address, $public_key, $message, $signature)
+action upsert_wallet_as_owner($id, $human_id, $address, $public_key, $wallet_type, $message, $signature) owner public {
+    INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
+    VALUES ($id, $human_id, $address, $public_key, $wallet_type, $message, $signature)
     ON CONFLICT(id) DO UPDATE
     SET human_id=$human_id, address=$address, public_key=$public_key, message=$message, signature=$signature;
 }
@@ -82,19 +83,29 @@ action delete_human_as_owner($id) owner public { //for testing period, for not t
     DELETE FROM humans WHERE id=$id;
 }
 
-action get_attributes() public view mustsign {
+@kgw(authn='true')
+action get_attributes() public view {
+    $converted = idos_near.hex_to_base58(@caller);
 	SELECT DISTINCT ha.id, ha.human_id, ha.attribute_key, ha.value, sha.original_id AS original_id
     FROM human_attributes AS ha
     LEFT JOIN shared_human_attributes AS sha ON ha.id = sha.duplicate_id
     INNER JOIN wallets ON ha.human_id = wallets.human_id
-    WHERE wallets.address = address(@caller) COLLATE NOCASE OR wallets.public_key = public_key(@caller, 'base64') COLLATE NOCASE;
+    WHERE (
+        wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE
+    ) OR (
+        wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted
+    );
 }
 
-action add_attribute($id, $attribute_key, $value) public mustsign {
+@kgw(authn='true')
+action add_attribute($id, $attribute_key, $value) public {
+    $converted = idos_near.hex_to_base58(@caller);
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
     VALUES (
         $id,
-        (SELECT DISTINCT human_id FROM wallets WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE),
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = $converted)
+        ),
         $attribute_key,
         $value
     );
@@ -110,41 +121,47 @@ action add_attribute_as_owner($id, $human_id, $attribute_key, $value) owner publ
     );
 }
 
-action edit_attribute($id, $attribute_key, $value) public mustsign {
+@kgw(authn='true')
+action edit_attribute($id, $attribute_key, $value) public {
+    $converted = idos_near.hex_to_base58(@caller);
     UPDATE human_attributes
     SET attribute_key=$attribute_key, value=$value
     WHERE id=$id
-    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE);
-}
-
-action remove_attribute($id) public mustsign {
-    DELETE FROM human_attributes
-    WHERE id=$id
-    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE);
-}
-
-action get_wallets() public view mustsign {
-    SELECT DISTINCT w1.*
-    FROM wallets AS w1
-    INNER JOIN wallets AS w2 ON w1.human_id = w2.human_id
-    WHERE w2.address = address(@caller) COLLATE NOCASE OR w2.public_key = public_key(@caller, 'base64') COLLATE NOCASE;
-}
-
-action add_wallet($id, $address, $message, $signature) public mustsign {
-    INSERT INTO wallets (id, human_id, address, public_key, message, signature)
-    VALUES (
-        $id,
-        (SELECT DISTINCT human_id FROM wallets WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE),
-        $address,
-        public_key(@caller, 'base64'),
-        $message,
-        $signature
+    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
     );
 }
 
-action remove_wallet($id) public mustsign {
+@kgw(authn='true')
+action remove_attribute($id) public {
+    $converted = idos_near.hex_to_base58(@caller);
+    DELETE FROM human_attributes
+    WHERE id=$id
+    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
+    );
+}
+
+@kgw(authn='true')
+action get_wallets() public view {
+    $converted = idos_near.hex_to_base58(@caller);
+    SELECT DISTINCT w1.*
+    FROM wallets AS w1
+    INNER JOIN wallets AS w2 ON w1.human_id = w2.human_id
+    WHERE (
+        w2.wallet_type = 'EVM' AND w2.address = @caller COLLATE NOCASE
+    ) OR (
+        w2.wallet_type = 'NEAR' AND w2.public_key = $converted
+    );
+}
+
+@kgw(authn='true')
+action remove_wallet($id) public {
+    $converted = idos_eth.hex_to_base58(@caller);
     DELETE FROM wallets
-    WHERE id=$id AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE);
+    WHERE id=$id AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
+    );
 }
 
 action has_profile($address) public view {
@@ -153,23 +170,37 @@ action has_profile($address) public view {
     ) AS has_profile;
 }
 
-action get_wallet_human_id() public view mustsign {
+@kgw(authn='true')
+action get_wallet_human_id() public view {
+    $converted = idos_eth.hex_to_base58(@caller);
     SELECT DISTINCT human_id FROM wallets
-    WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE;
+    WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted);
 }
-action get_credentials() public view mustsign {
+
+@kgw(authn='true')
+action get_credentials() public view {
+    $converted = idos_eth.hex_to_base58(@caller);
 	SELECT DISTINCT c.id, c.human_id, c.issuer, c.credential_type, c.credential_level, c.credential_status, sc.original_id AS original_id
     FROM credentials AS c
     LEFT JOIN shared_credentials AS sc ON c.id = sc.duplicate_id
     INNER JOIN wallets ON c.human_id = wallets.human_id
-    WHERE wallets.address = address(@caller) COLLATE NOCASE OR wallets.public_key = public_key(@caller, 'base64') COLLATE NOCASE;
+    WHERE (
+        wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE
+    ) OR (
+        wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted
+    );
 }
 
-action add_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public mustsign {
+@kgw(authn='true')
+action add_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
+    $converted = idos_eth.hex_to_base58(@caller);
     INSERT INTO credentials (id, human_id, issuer, credential_type, credential_level, credential_status, content, encryption_public_key)
     VALUES (
         $id,
-        (SELECT DISTINCT human_id from wallets WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE),
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = $converted)
+        ),
         $issuer,
         $credential_type,
         $credential_level,
@@ -179,11 +210,15 @@ action add_credential($id, $issuer, $credential_type, $credential_level, $creden
     );
 }
 
-action share_credential($id, $original_credential_id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public mustsign {
+@kgw(authn='true')
+action share_credential($id, $original_credential_id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
+    $converted = idos_eth.hex_to_base58(@caller);
     INSERT INTO credentials (id, human_id, issuer, credential_type, credential_level, credential_status, content, encryption_public_key)
     VALUES (
         $id,
-        (SELECT DISTINCT human_id from wallets WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE),
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = $converted)
+        ),
         $issuer,
         $credential_type,
         $credential_level,
@@ -195,30 +230,44 @@ action share_credential($id, $original_credential_id, $issuer, $credential_type,
     add_shared_credential($original_credential_id, $id);
 }
 
-action edit_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public mustsign {
+@kgw(authn='true')
+action edit_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
+    $converted = idos_eth.hex_to_base58(@caller);
     UPDATE credentials
     SET issuer=$issuer, credential_type=$credential_type, credential_level=$credential_level, credential_status=$credential_status, content=$content, encryption_public_key=$encryption_public_key
     WHERE id=$id
-    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE);
+    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
+    );
 }
 
-action remove_credential($id) public mustsign {
+@kgw(authn='true')
+action remove_credential($id) public {
+    $converted = idos_eth.hex_to_base58(@caller);
     DELETE FROM credentials
     WHERE id=$id
-    AND human_id=(SELECT human_id FROM wallets WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE);
+    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
+    );
 }
 
-action get_credential_owned ($id) public view mustsign {
+@kgw(authn='true')
+action get_credential_owned ($id) public view {
+    $converted = idos_eth.hex_to_base58(@caller);
     SELECT DISTINCT credentials.*
     FROM credentials
     INNER JOIN wallets ON credentials.human_id = wallets.human_id
     WHERE credentials.id = $id
-    AND (wallets.address = address(@caller) COLLATE NOCASE OR wallets.public_key = public_key(@caller, 'base64') COLLATE NOCASE);
+    AND (
+        (wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE)
+            OR (wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted)
+    );
 }
 
-action get_credential_shared ($id) public view mustsign {
-    $has_grant_on_eth = idos_eth.has_grants(address(@caller), $id);
-    $has_grant_on_near = idos_near.has_grants(address(@caller), $id);
+@kgw(authn='true')
+action get_credential_shared ($id) public view {
+    $has_grant_on_eth = idos_eth.has_grants(@caller, $id);
+    $has_grant_on_near = idos_near.has_grants(@caller, $id);
 
     SELECT CASE
         WHEN $has_grant_on_eth != 1 AND $has_grant_on_near != 1
@@ -229,11 +278,15 @@ action get_credential_shared ($id) public view mustsign {
     WHERE id = $id;
 }
 
-action share_attribute($id, $original_attribute_id, $attribute_key, $value) public mustsign {
+@kgw(authn='true')
+action share_attribute($id, $original_attribute_id, $attribute_key, $value) public {
+    $converted = idos_eth.hex_to_base58(@caller);
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
     VALUES (
         $id,
-        (SELECT DISTINCT human_id from wallets WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE),
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = $converted)
+        ),
         $attribute_key,
         $value
     );
@@ -249,4 +302,22 @@ action add_shared_credential($original_id, $duplicate_id) owner public {
 action add_shared_attribute($original_id, $duplicate_id) owner public {
     INSERT INTO shared_human_attributes (original_id, duplicate_id)
     VALUES ($original_id, $duplicate_id);
+}
+
+@kgw(authn='true')
+action add_wallet($id, $address, $message, $signature) public {
+    $converted = idos_near.hex_to_base58(@caller);
+    $wallet_type = idos_near.determine_wallet_type($address);
+    INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
+    VALUES (
+        $id,
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = $converted)
+        ),
+        $address,
+        NULL,
+        $wallet_type,
+        $message,
+        $signature
+    );
 }

--- a/schema.production.kf
+++ b/schema.production.kf
@@ -88,6 +88,10 @@ action delete_human_as_owner($id) owner public { //for testing period, for not t
     DELETE FROM humans WHERE id=$id;
 }
 
+action delete_wallet_as_owner($id) owner public { //temporary, to remove wrong data from initial test period
+    DELETE FROM wallets WHERE id=$id;
+}
+
 @kgw(authn='true')
 action get_attributes() public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);

--- a/schema.production.kf
+++ b/schema.production.kf
@@ -61,7 +61,7 @@ table shared_credentials {
     foreign_key (duplicate_id) references credentials(id) on_delete cascade
 }
 
-action add_human_as_owner($id) owner public { // this is temporary for easy adding users not through nautilus for test purposes
+action add_human_as_owner($id) owner public {
     INSERT INTO humans (id) VALUES ($id);
 }
 

--- a/schema.production.kf
+++ b/schema.production.kf
@@ -95,23 +95,26 @@ action delete_wallet_as_owner($id) owner public { //temporary, to remove wrong d
 @kgw(authn='true')
 action get_attributes() public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
 	SELECT DISTINCT ha.id, ha.human_id, ha.attribute_key, ha.value, sha.original_id AS original_id
     FROM human_attributes AS ha
     LEFT JOIN shared_human_attributes AS sha ON ha.id = sha.duplicate_id
-    WHERE ha.human_id = $current_human_id;
+    INNER JOIN wallets ON ha.human_id = wallets.human_id
+    WHERE (
+        wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE
+    ) OR (
+        wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted
+    );
 }
 
 @kgw(authn='true')
 action add_attribute($id, $attribute_key, $value) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
     VALUES (
         $id,
-        $current_human_id,
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = $converted)
+        ),
         $attribute_key,
         $value
     );
@@ -130,41 +133,44 @@ action add_attribute_as_owner($id, $human_id, $attribute_key, $value) owner publ
 @kgw(authn='true')
 action edit_attribute($id, $attribute_key, $value) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
     UPDATE human_attributes
     SET attribute_key=$attribute_key, value=$value
     WHERE id=$id
-    AND human_id=$current_human_id;
+    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
+    );
 }
 
 @kgw(authn='true')
 action remove_attribute($id) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
     DELETE FROM human_attributes
     WHERE id=$id
-    AND human_id=$current_human_id;
+    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
+    );
 }
 
 @kgw(authn='true')
 action get_wallets() public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
-    SELECT *
-    FROM wallets
-    WHERE human_id=$current_human_id;
+    SELECT DISTINCT w1.*
+    FROM wallets AS w1
+    INNER JOIN wallets AS w2 ON w1.human_id = w2.human_id
+    WHERE (
+        w2.wallet_type = 'EVM' AND w2.address = @caller COLLATE NOCASE
+    ) OR (
+        w2.wallet_type = 'NEAR' AND w2.public_key = $converted
+    );
 }
 
 @kgw(authn='true')
 action remove_wallet($id) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
     DELETE FROM wallets
-    WHERE id=$id AND human_id=$current_human_id;
+    WHERE id=$id AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
+    );
 }
 
 action has_profile($address) public view {
@@ -176,31 +182,34 @@ action has_profile($address) public view {
 @kgw(authn='true')
 action get_wallet_human_id() public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
-    SELECT $current_human_id as human_id;
+    SELECT DISTINCT human_id FROM wallets
+    WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted);
 }
 
 @kgw(authn='true')
 action get_credentials() public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
 	SELECT DISTINCT c.id, c.human_id, c.issuer, c.credential_type, c.credential_level, c.credential_status, sc.original_id AS original_id
     FROM credentials AS c
     LEFT JOIN shared_credentials AS sc ON c.id = sc.duplicate_id
-    WHERE c.human_id = $current_human_id;
+    INNER JOIN wallets ON c.human_id = wallets.human_id
+    WHERE (
+        wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE
+    ) OR (
+        wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted
+    );
 }
 
 @kgw(authn='true')
 action add_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
     INSERT INTO credentials (id, human_id, issuer, credential_type, credential_level, credential_status, content, encryption_public_key)
     VALUES (
         $id,
-        $current_human_id,
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = $converted)
+        ),
         $issuer,
         $credential_type,
         $credential_level,
@@ -213,12 +222,12 @@ action add_credential($id, $issuer, $credential_type, $credential_level, $creden
 @kgw(authn='true')
 action share_credential($id, $original_credential_id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
     INSERT INTO credentials (id, human_id, issuer, credential_type, credential_level, credential_status, content, encryption_public_key)
     VALUES (
         $id,
-        $current_human_id,
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = $converted)
+        ),
         $issuer,
         $credential_type,
         $credential_level,
@@ -233,33 +242,35 @@ action share_credential($id, $original_credential_id, $issuer, $credential_type,
 @kgw(authn='true')
 action edit_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
     UPDATE credentials
     SET issuer=$issuer, credential_type=$credential_type, credential_level=$credential_level, credential_status=$credential_status, content=$content, encryption_public_key=$encryption_public_key
     WHERE id=$id
-    AND human_id=$current_human_id;
+    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
+    );
 }
 
 @kgw(authn='true')
 action remove_credential($id) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
     DELETE FROM credentials
     WHERE id=$id
-    AND human_id=$current_human_id;
+    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
+    );
 }
 
 @kgw(authn='true')
 action get_credential_owned ($id) public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
     SELECT DISTINCT credentials.*
     FROM credentials
+    INNER JOIN wallets ON credentials.human_id = wallets.human_id
     WHERE credentials.id = $id
-    AND credentials.human_id = $current_human_id;
+    AND (
+        (wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE)
+            OR (wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted)
+    );
 }
 
 @kgw(authn='true')
@@ -279,12 +290,12 @@ action get_credential_shared ($id) public view {
 @kgw(authn='true')
 action share_attribute($id, $original_attribute_id, $attribute_key, $value) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
     VALUES (
         $id,
-        $current_human_id,
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = $converted)
+        ),
         $attribute_key,
         $value
     );
@@ -303,10 +314,9 @@ action add_shared_attribute($original_id, $duplicate_id) owner public {
 }
 
 @kgw(authn='true')
-action add_wallet($id, $address, $public_key, $message, $signature) public {
+action add_wallet($id, $address, $message, $signature) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     $wallet_type = idos_near.determine_wallet_type($address);
-    $current_human_id = caller_human_id();
 
     SELECT CASE
         WHEN $wallet_type = 'NEAR' AND ($public_key IS NULL OR length($public_key) != 52)
@@ -316,7 +326,9 @@ action add_wallet($id, $address, $public_key, $message, $signature) public {
     INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
     VALUES (
         $id,
-        $current_human_id,
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = $converted)
+        ),
         $address,
         CASE
             WHEN $public_key = '' THEN NULL
@@ -326,14 +338,4 @@ action add_wallet($id, $address, $public_key, $message, $signature) public {
         $message,
         $signature
     );
-}
-
-action caller_human_id() private view {
-    $converted = idos_near.implicit_address_to_public_key(@caller);
-    SELECT human_id
-    FROM wallets
-    WHERE
-        (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted)
-    LIMIT 1;
 }

--- a/schema.production.kf
+++ b/schema.production.kf
@@ -326,7 +326,10 @@ action add_wallet($id, $address, $message, $signature) public {
             OR (wallet_type = 'NEAR' AND public_key = $converted)
         ),
         $address,
-        NULL,
+        CASE
+            WHEN $public_key = '' THEN NULL
+            ELSE $public_key
+        END,
         $wallet_type,
         $message,
         $signature

--- a/schema.production.kf
+++ b/schema.production.kf
@@ -85,7 +85,7 @@ action delete_human_as_owner($id) owner public { //for testing period, for not t
 
 @kgw(authn='true')
 action get_attributes() public view {
-    $converted = idos_near.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
 	SELECT DISTINCT ha.id, ha.human_id, ha.attribute_key, ha.value, sha.original_id AS original_id
     FROM human_attributes AS ha
     LEFT JOIN shared_human_attributes AS sha ON ha.id = sha.duplicate_id
@@ -99,7 +99,7 @@ action get_attributes() public view {
 
 @kgw(authn='true')
 action add_attribute($id, $attribute_key, $value) public {
-    $converted = idos_near.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
     VALUES (
         $id,
@@ -123,7 +123,7 @@ action add_attribute_as_owner($id, $human_id, $attribute_key, $value) owner publ
 
 @kgw(authn='true')
 action edit_attribute($id, $attribute_key, $value) public {
-    $converted = idos_near.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     UPDATE human_attributes
     SET attribute_key=$attribute_key, value=$value
     WHERE id=$id
@@ -134,7 +134,7 @@ action edit_attribute($id, $attribute_key, $value) public {
 
 @kgw(authn='true')
 action remove_attribute($id) public {
-    $converted = idos_near.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     DELETE FROM human_attributes
     WHERE id=$id
     AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
@@ -144,7 +144,7 @@ action remove_attribute($id) public {
 
 @kgw(authn='true')
 action get_wallets() public view {
-    $converted = idos_near.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT DISTINCT w1.*
     FROM wallets AS w1
     INNER JOIN wallets AS w2 ON w1.human_id = w2.human_id
@@ -157,7 +157,7 @@ action get_wallets() public view {
 
 @kgw(authn='true')
 action remove_wallet($id) public {
-    $converted = idos_eth.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     DELETE FROM wallets
     WHERE id=$id AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
         OR (wallet_type = 'NEAR' AND public_key = $converted)
@@ -172,7 +172,7 @@ action has_profile($address) public view {
 
 @kgw(authn='true')
 action get_wallet_human_id() public view {
-    $converted = idos_eth.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT DISTINCT human_id FROM wallets
     WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
         OR (wallet_type = 'NEAR' AND public_key = $converted);
@@ -180,7 +180,7 @@ action get_wallet_human_id() public view {
 
 @kgw(authn='true')
 action get_credentials() public view {
-    $converted = idos_eth.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
 	SELECT DISTINCT c.id, c.human_id, c.issuer, c.credential_type, c.credential_level, c.credential_status, sc.original_id AS original_id
     FROM credentials AS c
     LEFT JOIN shared_credentials AS sc ON c.id = sc.duplicate_id
@@ -194,7 +194,7 @@ action get_credentials() public view {
 
 @kgw(authn='true')
 action add_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
-    $converted = idos_eth.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     INSERT INTO credentials (id, human_id, issuer, credential_type, credential_level, credential_status, content, encryption_public_key)
     VALUES (
         $id,
@@ -212,7 +212,7 @@ action add_credential($id, $issuer, $credential_type, $credential_level, $creden
 
 @kgw(authn='true')
 action share_credential($id, $original_credential_id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
-    $converted = idos_eth.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     INSERT INTO credentials (id, human_id, issuer, credential_type, credential_level, credential_status, content, encryption_public_key)
     VALUES (
         $id,
@@ -232,7 +232,7 @@ action share_credential($id, $original_credential_id, $issuer, $credential_type,
 
 @kgw(authn='true')
 action edit_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
-    $converted = idos_eth.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     UPDATE credentials
     SET issuer=$issuer, credential_type=$credential_type, credential_level=$credential_level, credential_status=$credential_status, content=$content, encryption_public_key=$encryption_public_key
     WHERE id=$id
@@ -243,7 +243,7 @@ action edit_credential($id, $issuer, $credential_type, $credential_level, $crede
 
 @kgw(authn='true')
 action remove_credential($id) public {
-    $converted = idos_eth.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     DELETE FROM credentials
     WHERE id=$id
     AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
@@ -253,7 +253,7 @@ action remove_credential($id) public {
 
 @kgw(authn='true')
 action get_credential_owned ($id) public view {
-    $converted = idos_eth.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT DISTINCT credentials.*
     FROM credentials
     INNER JOIN wallets ON credentials.human_id = wallets.human_id
@@ -280,7 +280,7 @@ action get_credential_shared ($id) public view {
 
 @kgw(authn='true')
 action share_attribute($id, $original_attribute_id, $attribute_key, $value) public {
-    $converted = idos_eth.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
     VALUES (
         $id,
@@ -306,7 +306,7 @@ action add_shared_attribute($original_id, $duplicate_id) owner public {
 
 @kgw(authn='true')
 action add_wallet($id, $address, $message, $signature) public {
-    $converted = idos_near.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     $wallet_type = idos_near.determine_wallet_type($address);
     INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
     VALUES (

--- a/schema.production.kf
+++ b/schema.production.kf
@@ -67,7 +67,7 @@ action add_human_as_owner($id) owner public {
 
 action upsert_wallet_as_owner($id, $human_id, $address, $public_key, $wallet_type, $message, $signature) owner public {
     SELECT CASE
-        WHEN $wallet_type = "NEAR" AND length($public_key) != 52
+        WHEN $wallet_type = 'NEAR' AND ($public_key IS NULL OR length($public_key) != 52)
         THEN ERROR('NEAR wallets require a valid public_key to be given.')
     END;
 
@@ -315,7 +315,7 @@ action add_wallet($id, $address, $message, $signature) public {
     $wallet_type = idos_near.determine_wallet_type($address);
 
     SELECT CASE
-        WHEN $wallet_type = "NEAR" AND length($public_key) != 52
+        WHEN $wallet_type = 'NEAR' AND ($public_key IS NULL OR length($public_key) != 52)
         THEN ERROR('NEAR wallets require a valid public_key to be given.')
     END;
 

--- a/schema.production.kf
+++ b/schema.production.kf
@@ -74,7 +74,7 @@ action upsert_wallet_as_owner($id, $human_id, $address, $public_key, $wallet_typ
     INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
     VALUES ($id, $human_id, $address, $public_key, $wallet_type, $message, $signature)
     ON CONFLICT(id) DO UPDATE
-    SET human_id=$human_id, address=$address, public_key=$public_key, message=$message, signature=$signature;
+    SET human_id=$human_id, address=$address, public_key=$public_key, wallet_type=$wallet_type, message=$message, signature=$signature;
 }
 
 action upsert_credential_as_owner($id, $human_id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) owner public {
@@ -314,7 +314,7 @@ action add_shared_attribute($original_id, $duplicate_id) owner public {
 }
 
 @kgw(authn='true')
-action add_wallet($id, $address, $message, $signature) public {
+action add_wallet($id, $address, $public_key, $message, $signature) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     $wallet_type = idos_near.determine_wallet_type($address);
 

--- a/schema.production.kf
+++ b/schema.production.kf
@@ -66,6 +66,11 @@ action add_human_as_owner($id) owner public {
 }
 
 action upsert_wallet_as_owner($id, $human_id, $address, $public_key, $wallet_type, $message, $signature) owner public {
+    SELECT CASE
+        WHEN $wallet_type = "NEAR" AND length($public_key) != 52
+        THEN ERROR('NEAR wallets require a valid public_key to be given.')
+    END;
+
     INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
     VALUES ($id, $human_id, $address, $public_key, $wallet_type, $message, $signature)
     ON CONFLICT(id) DO UPDATE
@@ -308,6 +313,12 @@ action add_shared_attribute($original_id, $duplicate_id) owner public {
 action add_wallet($id, $address, $message, $signature) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     $wallet_type = idos_near.determine_wallet_type($address);
+
+    SELECT CASE
+        WHEN $wallet_type = "NEAR" AND length($public_key) != 52
+        THEN ERROR('NEAR wallets require a valid public_key to be given.')
+    END;
+
     INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
     VALUES (
         $id,

--- a/schema.staging.kf
+++ b/schema.staging.kf
@@ -85,7 +85,7 @@ action delete_human_as_owner($id) owner public { //for testing period, for not t
 
 @kgw(authn='true')
 action get_attributes() public view {
-    $converted = idos_near.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
 	SELECT DISTINCT ha.id, ha.human_id, ha.attribute_key, ha.value, sha.original_id AS original_id
     FROM human_attributes AS ha
     LEFT JOIN shared_human_attributes AS sha ON ha.id = sha.duplicate_id
@@ -99,7 +99,7 @@ action get_attributes() public view {
 
 @kgw(authn='true')
 action add_attribute($id, $attribute_key, $value) public {
-    $converted = idos_near.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
     VALUES (
         $id,
@@ -123,7 +123,7 @@ action add_attribute_as_owner($id, $human_id, $attribute_key, $value) owner publ
 
 @kgw(authn='true')
 action edit_attribute($id, $attribute_key, $value) public {
-    $converted = idos_near.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     UPDATE human_attributes
     SET attribute_key=$attribute_key, value=$value
     WHERE id=$id
@@ -134,7 +134,7 @@ action edit_attribute($id, $attribute_key, $value) public {
 
 @kgw(authn='true')
 action remove_attribute($id) public {
-    $converted = idos_near.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     DELETE FROM human_attributes
     WHERE id=$id
     AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
@@ -144,7 +144,7 @@ action remove_attribute($id) public {
 
 @kgw(authn='true')
 action get_wallets() public view {
-    $converted = idos_near.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT DISTINCT w1.*
     FROM wallets AS w1
     INNER JOIN wallets AS w2 ON w1.human_id = w2.human_id
@@ -157,7 +157,7 @@ action get_wallets() public view {
 
 @kgw(authn='true')
 action remove_wallet($id) public {
-    $converted = idos_eth.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     DELETE FROM wallets
     WHERE id=$id AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
         OR (wallet_type = 'NEAR' AND public_key = $converted)
@@ -172,7 +172,7 @@ action has_profile($address) public view {
 
 @kgw(authn='true')
 action get_wallet_human_id() public view {
-    $converted = idos_eth.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT DISTINCT human_id FROM wallets
     WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
         OR (wallet_type = 'NEAR' AND public_key = $converted);
@@ -180,7 +180,7 @@ action get_wallet_human_id() public view {
 
 @kgw(authn='true')
 action get_credentials() public view {
-    $converted = idos_eth.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
 	SELECT DISTINCT c.id, c.human_id, c.issuer, c.credential_type, c.credential_level, c.credential_status, sc.original_id AS original_id
     FROM credentials AS c
     LEFT JOIN shared_credentials AS sc ON c.id = sc.duplicate_id
@@ -194,7 +194,7 @@ action get_credentials() public view {
 
 @kgw(authn='true')
 action add_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
-    $converted = idos_eth.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     INSERT INTO credentials (id, human_id, issuer, credential_type, credential_level, credential_status, content, encryption_public_key)
     VALUES (
         $id,
@@ -212,7 +212,7 @@ action add_credential($id, $issuer, $credential_type, $credential_level, $creden
 
 @kgw(authn='true')
 action share_credential($id, $original_credential_id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
-    $converted = idos_eth.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     INSERT INTO credentials (id, human_id, issuer, credential_type, credential_level, credential_status, content, encryption_public_key)
     VALUES (
         $id,
@@ -232,7 +232,7 @@ action share_credential($id, $original_credential_id, $issuer, $credential_type,
 
 @kgw(authn='true')
 action edit_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
-    $converted = idos_eth.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     UPDATE credentials
     SET issuer=$issuer, credential_type=$credential_type, credential_level=$credential_level, credential_status=$credential_status, content=$content, encryption_public_key=$encryption_public_key
     WHERE id=$id
@@ -243,7 +243,7 @@ action edit_credential($id, $issuer, $credential_type, $credential_level, $crede
 
 @kgw(authn='true')
 action remove_credential($id) public {
-    $converted = idos_eth.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     DELETE FROM credentials
     WHERE id=$id
     AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
@@ -253,7 +253,7 @@ action remove_credential($id) public {
 
 @kgw(authn='true')
 action get_credential_owned ($id) public view {
-    $converted = idos_eth.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT DISTINCT credentials.*
     FROM credentials
     INNER JOIN wallets ON credentials.human_id = wallets.human_id
@@ -280,7 +280,7 @@ action get_credential_shared ($id) public view {
 
 @kgw(authn='true')
 action share_attribute($id, $original_attribute_id, $attribute_key, $value) public {
-    $converted = idos_eth.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
     VALUES (
         $id,
@@ -306,7 +306,7 @@ action add_shared_attribute($original_id, $duplicate_id) owner public {
 
 @kgw(authn='true')
 action add_wallet($id, $address, $public_key, $message, $signature) public {
-    $converted = idos_near.hex_to_base58(@caller);
+    $converted = idos_near.implicit_address_to_public_key(@caller);
     $wallet_type = idos_near.determine_wallet_type($address);
     INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
     VALUES (

--- a/schema.staging.kf
+++ b/schema.staging.kf
@@ -66,10 +66,10 @@ action add_human_as_owner($id) owner public {
 }
 
 action upsert_wallet_as_owner($id, $human_id, $address, $public_key, $wallet_type, $message, $signature) owner public {
-    SELECT CASE
-        WHEN $wallet_type = 'NEAR' AND ($public_key IS NULL OR length($public_key) != 52)
-        THEN ERROR('NEAR wallets require a valid public_key to be given.')
-    END;
+    SELECT CASE WHEN $wallet_type = 'NEAR' AND $public_key IS NULL THEN ERROR('NEAR wallets require a public_key to be given.') END;
+
+    $valid_near_public_key = idos_near.is_valid_public_key($public_key);
+    SELECT CASE WHEN $wallet_type = 'NEAR' AND $valid_near_public_key != 1 THEN ERROR('Invalid or unsupported public key.') END;
 
     INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
     VALUES ($id, $human_id, $address, $public_key, $wallet_type, $message, $signature)
@@ -318,10 +318,10 @@ action add_wallet($id, $address, $public_key, $message, $signature) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     $wallet_type = idos_near.determine_wallet_type($address);
 
-    SELECT CASE
-        WHEN $wallet_type = 'NEAR' AND ($public_key IS NULL OR length($public_key) != 52)
-        THEN ERROR('NEAR wallets require a valid public_key to be given.')
-    END;
+    SELECT CASE WHEN $wallet_type = 'NEAR' AND $public_key IS NULL THEN ERROR('NEAR wallets require a public_key to be given.') END;
+
+    $valid_near_public_key = idos_near.is_valid_public_key($public_key);
+    SELECT CASE WHEN $wallet_type = 'NEAR' AND $valid_near_public_key != 1 THEN ERROR('Invalid or unsupported public key.') END;
 
     INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
     VALUES (

--- a/schema.staging.kf
+++ b/schema.staging.kf
@@ -33,8 +33,9 @@ table shared_human_attributes {
 table wallets {
     id text primary minlen(36) maxlen(36) notnull unique,
     human_id text minlen(36) maxlen(36) notnull,
-    address text notnull,
-    public_key text notnull,
+    address text,
+    public_key text,
+    wallet_type text notnull,
     message text,
     signature text,
     foreign_key (human_id) references humans(id) on_delete cascade
@@ -60,13 +61,13 @@ table shared_credentials {
     foreign_key (duplicate_id) references credentials(id) on_delete cascade
 }
 
-action add_human_as_owner($id) public { // this is temporary for easy adding users not through nautilus for test purposes
+action add_human_as_owner($id) owner public { // this is temporary for easy adding users not through nautilus for test purposes
     INSERT INTO humans (id) VALUES ($id);
 }
 
-action upsert_wallet_as_owner($id, $human_id, $address, $public_key, $message, $signature) owner public {
-    INSERT INTO wallets (id, human_id, address, public_key, message, signature)
-    VALUES ($id, $human_id, $address, $public_key, $message, $signature)
+action upsert_wallet_as_owner($id, $human_id, $address, $public_key, $wallet_type, $message, $signature) owner public {
+    INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
+    VALUES ($id, $human_id, $address, $public_key, $wallet_type, $message, $signature)
     ON CONFLICT(id) DO UPDATE
     SET human_id=$human_id, address=$address, public_key=$public_key, message=$message, signature=$signature;
 }
@@ -82,19 +83,29 @@ action delete_human_as_owner($id) owner public { //for testing period, for not t
     DELETE FROM humans WHERE id=$id;
 }
 
-action get_attributes() public view mustsign {
+@kgw(authn='true')
+action get_attributes() public view {
+    $converted = idos_near.hex_to_base58(@caller);
 	SELECT DISTINCT ha.id, ha.human_id, ha.attribute_key, ha.value, sha.original_id AS original_id
     FROM human_attributes AS ha
     LEFT JOIN shared_human_attributes AS sha ON ha.id = sha.duplicate_id
     INNER JOIN wallets ON ha.human_id = wallets.human_id
-    WHERE wallets.address = address(@caller) COLLATE NOCASE OR wallets.public_key = public_key(@caller, 'base64') COLLATE NOCASE;
+    WHERE (
+        wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE
+    ) OR (
+        wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted
+    );
 }
 
-action add_attribute($id, $attribute_key, $value) public mustsign {
+@kgw(authn='true')
+action add_attribute($id, $attribute_key, $value) public {
+    $converted = idos_near.hex_to_base58(@caller);
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
     VALUES (
         $id,
-        (SELECT DISTINCT human_id FROM wallets WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE),
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = $converted)
+        ),
         $attribute_key,
         $value
     );
@@ -110,41 +121,47 @@ action add_attribute_as_owner($id, $human_id, $attribute_key, $value) owner publ
     );
 }
 
-action edit_attribute($id, $attribute_key, $value) public mustsign {
+@kgw(authn='true')
+action edit_attribute($id, $attribute_key, $value) public {
+    $converted = idos_near.hex_to_base58(@caller);
     UPDATE human_attributes
     SET attribute_key=$attribute_key, value=$value
     WHERE id=$id
-    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE);
-}
-
-action remove_attribute($id) public mustsign {
-    DELETE FROM human_attributes
-    WHERE id=$id
-    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE);
-}
-
-action get_wallets() public view mustsign {
-    SELECT DISTINCT w1.*
-    FROM wallets AS w1
-    INNER JOIN wallets AS w2 ON w1.human_id = w2.human_id
-    WHERE w2.address = address(@caller) COLLATE NOCASE OR w2.public_key = public_key(@caller, 'base64') COLLATE NOCASE;
-}
-
-action add_wallet($id, $address, $message, $signature) public mustsign {
-    INSERT INTO wallets (id, human_id, address, public_key, message, signature)
-    VALUES (
-        $id,
-        (SELECT DISTINCT human_id FROM wallets WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE),
-        $address,
-        public_key(@caller, 'base64'),
-        $message,
-        $signature
+    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
     );
 }
 
-action remove_wallet($id) public mustsign {
+@kgw(authn='true')
+action remove_attribute($id) public {
+    $converted = idos_near.hex_to_base58(@caller);
+    DELETE FROM human_attributes
+    WHERE id=$id
+    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
+    );
+}
+
+@kgw(authn='true')
+action get_wallets() public view {
+    $converted = idos_near.hex_to_base58(@caller);
+    SELECT DISTINCT w1.*
+    FROM wallets AS w1
+    INNER JOIN wallets AS w2 ON w1.human_id = w2.human_id
+    WHERE (
+        w2.wallet_type = 'EVM' AND w2.address = @caller COLLATE NOCASE
+    ) OR (
+        w2.wallet_type = 'NEAR' AND w2.public_key = $converted
+    );
+}
+
+@kgw(authn='true')
+action remove_wallet($id) public {
+    $converted = idos_eth.hex_to_base58(@caller);
     DELETE FROM wallets
-    WHERE id=$id AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE);
+    WHERE id=$id AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
+    );
 }
 
 action has_profile($address) public view {
@@ -153,23 +170,37 @@ action has_profile($address) public view {
     ) AS has_profile;
 }
 
-action get_wallet_human_id() public view mustsign {
+@kgw(authn='true')
+action get_wallet_human_id() public view {
+    $converted = idos_eth.hex_to_base58(@caller);
     SELECT DISTINCT human_id FROM wallets
-    WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE;
+    WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted);
 }
-action get_credentials() public view mustsign {
+
+@kgw(authn='true')
+action get_credentials() public view {
+    $converted = idos_eth.hex_to_base58(@caller);
 	SELECT DISTINCT c.id, c.human_id, c.issuer, c.credential_type, c.credential_level, c.credential_status, sc.original_id AS original_id
     FROM credentials AS c
     LEFT JOIN shared_credentials AS sc ON c.id = sc.duplicate_id
     INNER JOIN wallets ON c.human_id = wallets.human_id
-    WHERE wallets.address = address(@caller) COLLATE NOCASE OR wallets.public_key = public_key(@caller, 'base64') COLLATE NOCASE;
+    WHERE (
+        wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE
+    ) OR (
+        wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted
+    );
 }
 
-action add_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public mustsign {
+@kgw(authn='true')
+action add_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
+    $converted = idos_eth.hex_to_base58(@caller);
     INSERT INTO credentials (id, human_id, issuer, credential_type, credential_level, credential_status, content, encryption_public_key)
     VALUES (
         $id,
-        (SELECT DISTINCT human_id from wallets WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE),
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = $converted)
+        ),
         $issuer,
         $credential_type,
         $credential_level,
@@ -179,11 +210,15 @@ action add_credential($id, $issuer, $credential_type, $credential_level, $creden
     );
 }
 
-action share_credential($id, $original_credential_id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public mustsign {
+@kgw(authn='true')
+action share_credential($id, $original_credential_id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
+    $converted = idos_eth.hex_to_base58(@caller);
     INSERT INTO credentials (id, human_id, issuer, credential_type, credential_level, credential_status, content, encryption_public_key)
     VALUES (
         $id,
-        (SELECT DISTINCT human_id from wallets WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE),
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = $converted)
+        ),
         $issuer,
         $credential_type,
         $credential_level,
@@ -195,30 +230,44 @@ action share_credential($id, $original_credential_id, $issuer, $credential_type,
     add_shared_credential($original_credential_id, $id);
 }
 
-action edit_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public mustsign {
+@kgw(authn='true')
+action edit_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
+    $converted = idos_eth.hex_to_base58(@caller);
     UPDATE credentials
     SET issuer=$issuer, credential_type=$credential_type, credential_level=$credential_level, credential_status=$credential_status, content=$content, encryption_public_key=$encryption_public_key
     WHERE id=$id
-    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE);
+    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
+    );
 }
 
-action remove_credential($id) public mustsign {
+@kgw(authn='true')
+action remove_credential($id) public {
+    $converted = idos_eth.hex_to_base58(@caller);
     DELETE FROM credentials
     WHERE id=$id
-    AND human_id=(SELECT human_id FROM wallets WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE);
+    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
+    );
 }
 
-action get_credential_owned ($id) public view mustsign {
+@kgw(authn='true')
+action get_credential_owned ($id) public view {
+    $converted = idos_eth.hex_to_base58(@caller);
     SELECT DISTINCT credentials.*
     FROM credentials
     INNER JOIN wallets ON credentials.human_id = wallets.human_id
     WHERE credentials.id = $id
-    AND (wallets.address = address(@caller) COLLATE NOCASE OR wallets.public_key = public_key(@caller, 'base64') COLLATE NOCASE);
+    AND (
+        (wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE)
+            OR (wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted)
+    );
 }
 
-action get_credential_shared ($id) public view mustsign {
-    $has_grant_on_eth = idos_eth.has_grants(address(@caller), $id);
-    $has_grant_on_near = idos_near.has_grants(address(@caller), $id);
+@kgw(authn='true')
+action get_credential_shared ($id) public view {
+    $has_grant_on_eth = idos_eth.has_grants(@caller, $id);
+    $has_grant_on_near = idos_near.has_grants(@caller, $id);
 
     SELECT CASE
         WHEN $has_grant_on_eth != 1 AND $has_grant_on_near != 1
@@ -229,11 +278,15 @@ action get_credential_shared ($id) public view mustsign {
     WHERE id = $id;
 }
 
-action share_attribute($id, $original_attribute_id, $attribute_key, $value) public mustsign {
+@kgw(authn='true')
+action share_attribute($id, $original_attribute_id, $attribute_key, $value) public {
+    $converted = idos_eth.hex_to_base58(@caller);
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
     VALUES (
         $id,
-        (SELECT DISTINCT human_id from wallets WHERE address=address(@caller) COLLATE NOCASE OR public_key = public_key(@caller, 'base64') COLLATE NOCASE),
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = $converted)
+        ),
         $attribute_key,
         $value
     );
@@ -249,4 +302,22 @@ action add_shared_credential($original_id, $duplicate_id) owner public {
 action add_shared_attribute($original_id, $duplicate_id) owner public {
     INSERT INTO shared_human_attributes (original_id, duplicate_id)
     VALUES ($original_id, $duplicate_id);
+}
+
+@kgw(authn='true')
+action add_wallet($id, $address, $message, $signature) public {
+    $converted = idos_near.hex_to_base58(@caller);
+    $wallet_type = idos_near.determine_wallet_type($address);
+    INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
+    VALUES (
+        $id,
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = $converted)
+        ),
+        $address,
+        NULL,
+        $wallet_type,
+        $message,
+        $signature
+    );
 }

--- a/schema.staging.kf
+++ b/schema.staging.kf
@@ -88,6 +88,10 @@ action delete_human_as_owner($id) owner public { //for testing period, for not t
     DELETE FROM humans WHERE id=$id;
 }
 
+action delete_wallet_as_owner($id) owner public { //temporary, to remove wrong data from initial test period
+    DELETE FROM wallets WHERE id=$id;
+}
+
 @kgw(authn='true')
 action get_attributes() public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);

--- a/schema.staging.kf
+++ b/schema.staging.kf
@@ -61,7 +61,7 @@ table shared_credentials {
     foreign_key (duplicate_id) references credentials(id) on_delete cascade
 }
 
-action add_human_as_owner($id) owner public { // this is temporary for easy adding users not through nautilus for test purposes
+action add_human_as_owner($id) owner public {
     INSERT INTO humans (id) VALUES ($id);
 }
 

--- a/schema.staging.kf
+++ b/schema.staging.kf
@@ -95,23 +95,26 @@ action delete_wallet_as_owner($id) owner public { //temporary, to remove wrong d
 @kgw(authn='true')
 action get_attributes() public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
 	SELECT DISTINCT ha.id, ha.human_id, ha.attribute_key, ha.value, sha.original_id AS original_id
     FROM human_attributes AS ha
     LEFT JOIN shared_human_attributes AS sha ON ha.id = sha.duplicate_id
-    WHERE ha.human_id = $current_human_id;
+    INNER JOIN wallets ON ha.human_id = wallets.human_id
+    WHERE (
+        wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE
+    ) OR (
+        wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted
+    );
 }
 
 @kgw(authn='true')
 action add_attribute($id, $attribute_key, $value) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
     VALUES (
         $id,
-        $current_human_id,
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = $converted)
+        ),
         $attribute_key,
         $value
     );
@@ -130,41 +133,44 @@ action add_attribute_as_owner($id, $human_id, $attribute_key, $value) owner publ
 @kgw(authn='true')
 action edit_attribute($id, $attribute_key, $value) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
     UPDATE human_attributes
     SET attribute_key=$attribute_key, value=$value
     WHERE id=$id
-    AND human_id=$current_human_id;
+    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
+    );
 }
 
 @kgw(authn='true')
 action remove_attribute($id) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
     DELETE FROM human_attributes
     WHERE id=$id
-    AND human_id=$current_human_id;
+    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
+    );
 }
 
 @kgw(authn='true')
 action get_wallets() public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
-    SELECT *
-    FROM wallets
-    WHERE human_id=$current_human_id;
+    SELECT DISTINCT w1.*
+    FROM wallets AS w1
+    INNER JOIN wallets AS w2 ON w1.human_id = w2.human_id
+    WHERE (
+        w2.wallet_type = 'EVM' AND w2.address = @caller COLLATE NOCASE
+    ) OR (
+        w2.wallet_type = 'NEAR' AND w2.public_key = $converted
+    );
 }
 
 @kgw(authn='true')
 action remove_wallet($id) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
     DELETE FROM wallets
-    WHERE id=$id AND human_id=$current_human_id;
+    WHERE id=$id AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
+    );
 }
 
 action has_profile($address) public view {
@@ -176,31 +182,34 @@ action has_profile($address) public view {
 @kgw(authn='true')
 action get_wallet_human_id() public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
-    SELECT $current_human_id as human_id;
+    SELECT DISTINCT human_id FROM wallets
+    WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted);
 }
 
 @kgw(authn='true')
 action get_credentials() public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
 	SELECT DISTINCT c.id, c.human_id, c.issuer, c.credential_type, c.credential_level, c.credential_status, sc.original_id AS original_id
     FROM credentials AS c
     LEFT JOIN shared_credentials AS sc ON c.id = sc.duplicate_id
-    WHERE c.human_id = $current_human_id;
+    INNER JOIN wallets ON c.human_id = wallets.human_id
+    WHERE (
+        wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE
+    ) OR (
+        wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted
+    );
 }
 
 @kgw(authn='true')
 action add_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
     INSERT INTO credentials (id, human_id, issuer, credential_type, credential_level, credential_status, content, encryption_public_key)
     VALUES (
         $id,
-        $current_human_id,
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = $converted)
+        ),
         $issuer,
         $credential_type,
         $credential_level,
@@ -213,12 +222,12 @@ action add_credential($id, $issuer, $credential_type, $credential_level, $creden
 @kgw(authn='true')
 action share_credential($id, $original_credential_id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
     INSERT INTO credentials (id, human_id, issuer, credential_type, credential_level, credential_status, content, encryption_public_key)
     VALUES (
         $id,
-        $current_human_id,
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = $converted)
+        ),
         $issuer,
         $credential_type,
         $credential_level,
@@ -233,33 +242,35 @@ action share_credential($id, $original_credential_id, $issuer, $credential_type,
 @kgw(authn='true')
 action edit_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
     UPDATE credentials
     SET issuer=$issuer, credential_type=$credential_type, credential_level=$credential_level, credential_status=$credential_status, content=$content, encryption_public_key=$encryption_public_key
     WHERE id=$id
-    AND human_id=$current_human_id;
+    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
+    );
 }
 
 @kgw(authn='true')
 action remove_credential($id) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
     DELETE FROM credentials
     WHERE id=$id
-    AND human_id=$current_human_id;
+    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
+    );
 }
 
 @kgw(authn='true')
 action get_credential_owned ($id) public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
     SELECT DISTINCT credentials.*
     FROM credentials
+    INNER JOIN wallets ON credentials.human_id = wallets.human_id
     WHERE credentials.id = $id
-    AND credentials.human_id = $current_human_id;
+    AND (
+        (wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE)
+            OR (wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted)
+    );
 }
 
 @kgw(authn='true')
@@ -279,12 +290,12 @@ action get_credential_shared ($id) public view {
 @kgw(authn='true')
 action share_attribute($id, $original_attribute_id, $attribute_key, $value) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    $current_human_id = caller_human_id();
-
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
     VALUES (
         $id,
-        $current_human_id,
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = $converted)
+        ),
         $attribute_key,
         $value
     );
@@ -306,7 +317,6 @@ action add_shared_attribute($original_id, $duplicate_id) owner public {
 action add_wallet($id, $address, $public_key, $message, $signature) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     $wallet_type = idos_near.determine_wallet_type($address);
-    $current_human_id = caller_human_id();
 
     SELECT CASE
         WHEN $wallet_type = 'NEAR' AND ($public_key IS NULL OR length($public_key) != 52)
@@ -316,7 +326,9 @@ action add_wallet($id, $address, $public_key, $message, $signature) public {
     INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
     VALUES (
         $id,
-        $current_human_id,
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = $converted)
+        ),
         $address,
         CASE
             WHEN $public_key = '' THEN NULL
@@ -326,14 +338,4 @@ action add_wallet($id, $address, $public_key, $message, $signature) public {
         $message,
         $signature
     );
-}
-
-action caller_human_id() private view {
-    $converted = idos_near.implicit_address_to_public_key(@caller);
-    SELECT human_id
-    FROM wallets
-    WHERE
-        (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted)
-    LIMIT 1;
 }

--- a/schema.staging.kf
+++ b/schema.staging.kf
@@ -74,7 +74,7 @@ action upsert_wallet_as_owner($id, $human_id, $address, $public_key, $wallet_typ
     INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
     VALUES ($id, $human_id, $address, $public_key, $wallet_type, $message, $signature)
     ON CONFLICT(id) DO UPDATE
-    SET human_id=$human_id, address=$address, public_key=$public_key, message=$message, signature=$signature;
+    SET human_id=$human_id, address=$address, public_key=$public_key, wallet_type=$wallet_type, message=$message, signature=$signature;
 }
 
 action upsert_credential_as_owner($id, $human_id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) owner public {

--- a/schema.staging.kf
+++ b/schema.staging.kf
@@ -33,7 +33,7 @@ table shared_human_attributes {
 table wallets {
     id text primary minlen(36) maxlen(36) notnull unique,
     human_id text minlen(36) maxlen(36) notnull,
-    address text,
+    address text notnull,
     public_key text,
     wallet_type text notnull,
     message text,
@@ -305,7 +305,7 @@ action add_shared_attribute($original_id, $duplicate_id) owner public {
 }
 
 @kgw(authn='true')
-action add_wallet($id, $address, $message, $signature) public {
+action add_wallet($id, $address, $public_key, $message, $signature) public {
     $converted = idos_near.hex_to_base58(@caller);
     $wallet_type = idos_near.determine_wallet_type($address);
     INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
@@ -315,7 +315,10 @@ action add_wallet($id, $address, $message, $signature) public {
             OR (wallet_type = 'NEAR' AND public_key = $converted)
         ),
         $address,
-        NULL,
+        SELECT CASE
+            WHEN $public_key = '' OR $public_key = NULL THEN NULL
+            ELSE $public_key
+        END,
         $wallet_type,
         $message,
         $signature

--- a/schema.staging.kf
+++ b/schema.staging.kf
@@ -326,8 +326,8 @@ action add_wallet($id, $address, $public_key, $message, $signature) public {
             OR (wallet_type = 'NEAR' AND public_key = $converted)
         ),
         $address,
-        SELECT CASE
-            WHEN $public_key = '' OR $public_key = NULL THEN NULL
+        CASE
+            WHEN $public_key = '' THEN NULL
             ELSE $public_key
         END,
         $wallet_type,

--- a/schema.staging.kf
+++ b/schema.staging.kf
@@ -66,6 +66,11 @@ action add_human_as_owner($id) owner public {
 }
 
 action upsert_wallet_as_owner($id, $human_id, $address, $public_key, $wallet_type, $message, $signature) owner public {
+    SELECT CASE
+        WHEN $wallet_type = "NEAR" AND length($public_key) != 52
+        THEN ERROR('NEAR wallets require a valid public_key to be given.')
+    END;
+
     INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
     VALUES ($id, $human_id, $address, $public_key, $wallet_type, $message, $signature)
     ON CONFLICT(id) DO UPDATE
@@ -308,6 +313,12 @@ action add_shared_attribute($original_id, $duplicate_id) owner public {
 action add_wallet($id, $address, $public_key, $message, $signature) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     $wallet_type = idos_near.determine_wallet_type($address);
+
+    SELECT CASE
+        WHEN $wallet_type = "NEAR" AND length($public_key) != 52
+        THEN ERROR('NEAR wallets require a valid public_key to be given.')
+    END;
+
     INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
     VALUES (
         $id,

--- a/schema.staging.kf
+++ b/schema.staging.kf
@@ -91,26 +91,23 @@ action delete_human_as_owner($id) owner public { //for testing period, for not t
 @kgw(authn='true')
 action get_attributes() public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
 	SELECT DISTINCT ha.id, ha.human_id, ha.attribute_key, ha.value, sha.original_id AS original_id
     FROM human_attributes AS ha
     LEFT JOIN shared_human_attributes AS sha ON ha.id = sha.duplicate_id
-    INNER JOIN wallets ON ha.human_id = wallets.human_id
-    WHERE (
-        wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE
-    ) OR (
-        wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted
-    );
+    WHERE ha.human_id = $current_human_id;
 }
 
 @kgw(authn='true')
 action add_attribute($id, $attribute_key, $value) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
     VALUES (
         $id,
-        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-            OR (wallet_type = 'NEAR' AND public_key = $converted)
-        ),
+        $current_human_id,
         $attribute_key,
         $value
     );
@@ -129,44 +126,41 @@ action add_attribute_as_owner($id, $human_id, $attribute_key, $value) owner publ
 @kgw(authn='true')
 action edit_attribute($id, $attribute_key, $value) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
     UPDATE human_attributes
     SET attribute_key=$attribute_key, value=$value
     WHERE id=$id
-    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted)
-    );
+    AND human_id=$current_human_id;
 }
 
 @kgw(authn='true')
 action remove_attribute($id) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
     DELETE FROM human_attributes
     WHERE id=$id
-    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted)
-    );
+    AND human_id=$current_human_id;
 }
 
 @kgw(authn='true')
 action get_wallets() public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    SELECT DISTINCT w1.*
-    FROM wallets AS w1
-    INNER JOIN wallets AS w2 ON w1.human_id = w2.human_id
-    WHERE (
-        w2.wallet_type = 'EVM' AND w2.address = @caller COLLATE NOCASE
-    ) OR (
-        w2.wallet_type = 'NEAR' AND w2.public_key = $converted
-    );
+    $current_human_id = caller_human_id();
+
+    SELECT *
+    FROM wallets
+    WHERE human_id=$current_human_id;
 }
 
 @kgw(authn='true')
 action remove_wallet($id) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
     DELETE FROM wallets
-    WHERE id=$id AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted)
-    );
+    WHERE id=$id AND human_id=$current_human_id;
 }
 
 action has_profile($address) public view {
@@ -178,34 +172,31 @@ action has_profile($address) public view {
 @kgw(authn='true')
 action get_wallet_human_id() public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
-    SELECT DISTINCT human_id FROM wallets
-    WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted);
+    $current_human_id = caller_human_id();
+
+    SELECT $current_human_id as human_id;
 }
 
 @kgw(authn='true')
 action get_credentials() public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
 	SELECT DISTINCT c.id, c.human_id, c.issuer, c.credential_type, c.credential_level, c.credential_status, sc.original_id AS original_id
     FROM credentials AS c
     LEFT JOIN shared_credentials AS sc ON c.id = sc.duplicate_id
-    INNER JOIN wallets ON c.human_id = wallets.human_id
-    WHERE (
-        wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE
-    ) OR (
-        wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted
-    );
+    WHERE c.human_id = $current_human_id;
 }
 
 @kgw(authn='true')
 action add_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
     INSERT INTO credentials (id, human_id, issuer, credential_type, credential_level, credential_status, content, encryption_public_key)
     VALUES (
         $id,
-        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-            OR (wallet_type = 'NEAR' AND public_key = $converted)
-        ),
+        $current_human_id,
         $issuer,
         $credential_type,
         $credential_level,
@@ -218,12 +209,12 @@ action add_credential($id, $issuer, $credential_type, $credential_level, $creden
 @kgw(authn='true')
 action share_credential($id, $original_credential_id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
     INSERT INTO credentials (id, human_id, issuer, credential_type, credential_level, credential_status, content, encryption_public_key)
     VALUES (
         $id,
-        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-            OR (wallet_type = 'NEAR' AND public_key = $converted)
-        ),
+        $current_human_id,
         $issuer,
         $credential_type,
         $credential_level,
@@ -238,35 +229,33 @@ action share_credential($id, $original_credential_id, $issuer, $credential_type,
 @kgw(authn='true')
 action edit_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
     UPDATE credentials
     SET issuer=$issuer, credential_type=$credential_type, credential_level=$credential_level, credential_status=$credential_status, content=$content, encryption_public_key=$encryption_public_key
     WHERE id=$id
-    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted)
-    );
+    AND human_id=$current_human_id;
 }
 
 @kgw(authn='true')
 action remove_credential($id) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
     DELETE FROM credentials
     WHERE id=$id
-    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted)
-    );
+    AND human_id=$current_human_id;
 }
 
 @kgw(authn='true')
 action get_credential_owned ($id) public view {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
     SELECT DISTINCT credentials.*
     FROM credentials
-    INNER JOIN wallets ON credentials.human_id = wallets.human_id
     WHERE credentials.id = $id
-    AND (
-        (wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE)
-            OR (wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted)
-    );
+    AND credentials.human_id = $current_human_id;
 }
 
 @kgw(authn='true')
@@ -286,12 +275,12 @@ action get_credential_shared ($id) public view {
 @kgw(authn='true')
 action share_attribute($id, $original_attribute_id, $attribute_key, $value) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
+    $current_human_id = caller_human_id();
+
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
     VALUES (
         $id,
-        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-            OR (wallet_type = 'NEAR' AND public_key = $converted)
-        ),
+        $current_human_id,
         $attribute_key,
         $value
     );
@@ -313,6 +302,7 @@ action add_shared_attribute($original_id, $duplicate_id) owner public {
 action add_wallet($id, $address, $public_key, $message, $signature) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     $wallet_type = idos_near.determine_wallet_type($address);
+    $current_human_id = caller_human_id();
 
     SELECT CASE
         WHEN $wallet_type = 'NEAR' AND ($public_key IS NULL OR length($public_key) != 52)
@@ -322,9 +312,7 @@ action add_wallet($id, $address, $public_key, $message, $signature) public {
     INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
     VALUES (
         $id,
-        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-            OR (wallet_type = 'NEAR' AND public_key = $converted)
-        ),
+        $current_human_id,
         $address,
         CASE
             WHEN $public_key = '' THEN NULL
@@ -334,4 +322,14 @@ action add_wallet($id, $address, $public_key, $message, $signature) public {
         $message,
         $signature
     );
+}
+
+action caller_human_id() private view {
+    $converted = idos_near.implicit_address_to_public_key(@caller);
+    SELECT human_id
+    FROM wallets
+    WHERE
+        (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = $converted)
+    LIMIT 1;
 }

--- a/schema.staging.kf
+++ b/schema.staging.kf
@@ -67,7 +67,7 @@ action add_human_as_owner($id) owner public {
 
 action upsert_wallet_as_owner($id, $human_id, $address, $public_key, $wallet_type, $message, $signature) owner public {
     SELECT CASE
-        WHEN $wallet_type = "NEAR" AND length($public_key) != 52
+        WHEN $wallet_type = 'NEAR' AND ($public_key IS NULL OR length($public_key) != 52)
         THEN ERROR('NEAR wallets require a valid public_key to be given.')
     END;
 
@@ -315,7 +315,7 @@ action add_wallet($id, $address, $public_key, $message, $signature) public {
     $wallet_type = idos_near.determine_wallet_type($address);
 
     SELECT CASE
-        WHEN $wallet_type = "NEAR" AND length($public_key) != 52
+        WHEN $wallet_type = 'NEAR' AND ($public_key IS NULL OR length($public_key) != 52)
         THEN ERROR('NEAR wallets require a valid public_key to be given.')
     END;
 


### PR DESCRIPTION
Due to Kwil new 0.6.6 version we have to make changes:

- We can get no more `address(@caller)` and `public_key(@caller, 'base64')`. Now `@caller` is hex **address** for `Evm` and **implicit account** for `Near` (hex representation of public key of full access keypair)
- Some actions attributes no more exist, like `view`, `mustsign`, etc.
- Action requires authentication only if it has magic string `@kgw(authn='true')` above
- To deal with Near imlicit account we have to create a new extension method `idos_near.hex_to_base58(@caller)`
- To distinguish wallets of different types we add `wallet_type` field to `wallets` table (we can't name the field by name `type` as it is reserved word)