### PR TITLE
Adjust the schema to 0.7

### DIFF
--- a/schema.development.kf
+++ b/schema.development.kf
@@ -1,12 +1,12 @@
 database idos;
 
 use idos {
-    registry_address: '0xd75fE3089a983fDB28a18BaB3ff625a6a49C0C00',
+    registry_address: '0x827310fF816EfD65406a40cb1358cc82Bc2F5cF9',
     chain: 'eth'
 } as idos_eth;
 
 use idos {
-    registry_address: 'idos-dev-1.testnet',
+    registry_address: 'idos-dev-4.testnet',
     chain: 'near'
 } as idos_near;
 
@@ -86,8 +86,8 @@ action delete_delegate_as_owner($address) owner public {
 
 action authorize_delegate() private {
     SELECT CASE
-        WHEN NOT EXISTS(SELECT 1 FROM delegates WHERE address = @caller collate nocase)
-        THEN ERROR('Unauthorized writer: ' || @caller)
+        WHEN NOT EXISTS (SELECT 1 FROM delegates WHERE address = @caller COLLATE NOCASE)
+        THEN ERROR('Unauthorized writer')
     END;
 }
 

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -178,7 +178,7 @@ action add_attribute_as_owner($id, $human_id, $attribute_key, $value) public {
 action edit_attribute($id, $attribute_key, $value) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT CASE
-        WHEN (
+        WHEN EXISTS (
             SELECT 1 from human_attributes AS ha
                 INNER JOIN shared_human_attributes AS sha on ha.id = sha.duplicate_id
                 WHERE ha.id = $id
@@ -225,7 +225,7 @@ action remove_wallet($id) public {
 }
 
 action has_profile($address) public view {
-    SELECT EXISTS(
+    SELECT EXISTS (
         SELECT 1 FROM wallets WHERE address=$address COLLATE NOCASE
     ) AS has_profile;
 }
@@ -292,7 +292,7 @@ action share_credential($id, $original_credential_id, $issuer, $credential_type,
 action edit_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT CASE
-        WHEN (
+        WHEN EXISTS (
             SELECT 1 from credentials AS c
                 INNER JOIN shared_credentials AS sc on c.id = sc.duplicate_id
                 WHERE c.id = $id

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -407,9 +407,3 @@ action add_wallet($id, $address, $public_key, $message, $signature) public {
         $signature
     );
 }
-
-@kgw(authn='true')
-action get_me() public view {
-    $converted = idos_near.implicit_address_to_public_key(@caller);
-    SELECT @caller as caller, $converted as converted;
-}

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -1,7 +1,7 @@
 database idos;
 
 use idos {
-    registry_address: '0x827310fF816EfD65406a40cb1358cc82Bc2F5cF9',
+    registry_address: '0xd75fE3089a983fDB28a18BaB3ff625a6a49C0C00',
     chain: 'eth'
 } as idos_eth;
 

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -1,7 +1,7 @@
 database idos;
 
 use idos {
-    registry_address: '0xd75fE3089a983fDB28a18BaB3ff625a6a49C0C00',
+    registry_address: '0x827310fF816EfD65406a40cb1358cc82Bc2F5cF9',
     chain: 'eth'
 } as idos_eth;
 
@@ -102,7 +102,7 @@ action upsert_wallet_as_owner($id, $human_id, $address, $public_key, $wallet_typ
 
     INSERT INTO humans (id) VALUES ($human_id) ON CONFLICT(id) DO NOTHING;
 
-    SELECT CASE WHEN $wallet_type = 'NEAR' AND $public_key IS NULL THEN ERROR('NEAR wallets require a public_key to be given.') END;
+    SELECT CASE WHEN $wallet_type = 'NEAR' AND $public_key::TEXT IS NULL THEN ERROR('NEAR wallets require a public_key to be given.') END;
 
     $valid_near_public_key = idos_near.is_valid_public_key($public_key);
     SELECT CASE WHEN $wallet_type = 'NEAR' AND $valid_near_public_key != 1 THEN ERROR('Invalid or unsupported public key.') END;
@@ -150,7 +150,6 @@ action get_attributes() public view {
     );
 }
 
-@kgw(authn='true')
 action add_attribute($id, $attribute_key, $value) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
@@ -176,7 +175,6 @@ action add_attribute_as_owner($id, $human_id, $attribute_key, $value) public {
     );
 }
 
-@kgw(authn='true')
 action edit_attribute($id, $attribute_key, $value) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT CASE
@@ -196,7 +194,6 @@ action edit_attribute($id, $attribute_key, $value) public {
     );
 }
 
-@kgw(authn='true')
 action remove_attribute($id) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     DELETE FROM human_attributes
@@ -219,7 +216,6 @@ action get_wallets() public view {
     );
 }
 
-@kgw(authn='true')
 action remove_wallet($id) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     DELETE FROM wallets
@@ -256,7 +252,6 @@ action get_credentials() public view {
     );
 }
 
-@kgw(authn='true')
 action add_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     INSERT INTO credentials (id, human_id, issuer, credential_type, credential_level, credential_status, content, encryption_public_key)
@@ -274,7 +269,6 @@ action add_credential($id, $issuer, $credential_type, $credential_level, $creden
     );
 }
 
-@kgw(authn='true')
 action share_credential($id, $original_credential_id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     INSERT INTO credentials (id, human_id, issuer, credential_type, credential_level, credential_status, content, encryption_public_key)
@@ -295,7 +289,6 @@ action share_credential($id, $original_credential_id, $issuer, $credential_type,
     VALUES ($original_credential_id, $id);
 }
 
-@kgw(authn='true')
 action edit_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT CASE
@@ -315,7 +308,6 @@ action edit_credential($id, $issuer, $credential_type, $credential_level, $crede
     );
 }
 
-@kgw(authn='true')
 action remove_credential($id) public {
     $has_locked_grants_eth = idos_eth.has_locked_grants(@caller, $id);
     $has_locked_grants_near = idos_near.has_locked_grants(@caller, $id);
@@ -360,7 +352,6 @@ action get_credential_shared ($id) public view {
     WHERE id = $id;
 }
 
-@kgw(authn='true')
 action share_attribute($id, $original_attribute_id, $attribute_key, $value) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
@@ -391,12 +382,11 @@ action add_shared_attribute($original_id, $duplicate_id) public {
     VALUES ($original_id, $duplicate_id);
 }
 
-@kgw(authn='true')
 action add_wallet($id, $address, $public_key, $message, $signature) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     $wallet_type = idos_near.determine_wallet_type($address);
 
-    SELECT CASE WHEN $wallet_type = 'NEAR' AND $public_key IS NULL THEN ERROR('NEAR wallets require a public_key to be given.') END;
+    SELECT CASE WHEN $wallet_type = 'NEAR' AND $public_key::TEXT IS NULL THEN ERROR('NEAR wallets require a public_key to be given.') END;
 
     $valid_near_public_key = idos_near.is_valid_public_key($public_key);
     SELECT CASE WHEN $wallet_type = 'NEAR' AND $valid_near_public_key != 1 THEN ERROR('Invalid or unsupported public key.') END;
@@ -416,4 +406,10 @@ action add_wallet($id, $address, $public_key, $message, $signature) public {
         $message,
         $signature
     );
+}
+
+@kgw(authn='true')
+action get_me() public view {
+    $converted = idos_near.implicit_address_to_public_key(@caller);
+    SELECT @caller as caller, $converted as converted;
 }

--- a/schema.playground.kf
+++ b/schema.playground.kf
@@ -86,7 +86,7 @@ action delete_delegate_as_owner($address) owner public {
 
 action authorize_delegate() private {
     SELECT CASE
-        WHEN NOT EXISTS(SELECT 1 FROM delegates WHERE address = @caller collate nocase)
+        WHEN NOT EXISTS (SELECT 1 FROM delegates WHERE address = @caller collate nocase)
         THEN ERROR('Unauthorized writer')
     END;
 }
@@ -178,7 +178,7 @@ action add_attribute_as_owner($id, $human_id, $attribute_key, $value) public {
 action edit_attribute($id, $attribute_key, $value) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT CASE
-        WHEN (
+        WHEN EXISTS (
             SELECT 1 from human_attributes AS ha
                 INNER JOIN shared_human_attributes AS sha on ha.id = sha.duplicate_id
                 WHERE ha.id = $id
@@ -225,7 +225,7 @@ action remove_wallet($id) public {
 }
 
 action has_profile($address) public view {
-    SELECT EXISTS(
+    SELECT EXISTS (
         SELECT 1 FROM wallets WHERE address=$address COLLATE NOCASE
     ) AS has_profile;
 }
@@ -292,7 +292,7 @@ action share_credential($id, $original_credential_id, $issuer, $credential_type,
 action edit_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT CASE
-        WHEN (
+        WHEN EXISTS (
             SELECT 1 from credentials AS c
                 INNER JOIN shared_credentials AS sc on c.id = sc.duplicate_id
                 WHERE c.id = $id

--- a/schema.playground.kf
+++ b/schema.playground.kf
@@ -102,7 +102,7 @@ action upsert_wallet_as_owner($id, $human_id, $address, $public_key, $wallet_typ
 
     INSERT INTO humans (id) VALUES ($human_id) ON CONFLICT(id) DO NOTHING;
 
-    SELECT CASE WHEN $wallet_type = 'NEAR' AND $public_key IS NULL THEN ERROR('NEAR wallets require a public_key to be given.') END;
+    SELECT CASE WHEN $wallet_type = 'NEAR' AND $public_key::TEXT IS NULL THEN ERROR('NEAR wallets require a public_key to be given.') END;
 
     $valid_near_public_key = idos_near.is_valid_public_key($public_key);
     SELECT CASE WHEN $wallet_type = 'NEAR' AND $valid_near_public_key != 1 THEN ERROR('Invalid or unsupported public key.') END;
@@ -150,7 +150,6 @@ action get_attributes() public view {
     );
 }
 
-@kgw(authn='true')
 action add_attribute($id, $attribute_key, $value) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
@@ -176,7 +175,6 @@ action add_attribute_as_owner($id, $human_id, $attribute_key, $value) public {
     );
 }
 
-@kgw(authn='true')
 action edit_attribute($id, $attribute_key, $value) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT CASE
@@ -196,7 +194,6 @@ action edit_attribute($id, $attribute_key, $value) public {
     );
 }
 
-@kgw(authn='true')
 action remove_attribute($id) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     DELETE FROM human_attributes
@@ -219,7 +216,6 @@ action get_wallets() public view {
     );
 }
 
-@kgw(authn='true')
 action remove_wallet($id) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     DELETE FROM wallets
@@ -256,7 +252,6 @@ action get_credentials() public view {
     );
 }
 
-@kgw(authn='true')
 action add_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     INSERT INTO credentials (id, human_id, issuer, credential_type, credential_level, credential_status, content, encryption_public_key)
@@ -274,7 +269,6 @@ action add_credential($id, $issuer, $credential_type, $credential_level, $creden
     );
 }
 
-@kgw(authn='true')
 action share_credential($id, $original_credential_id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     INSERT INTO credentials (id, human_id, issuer, credential_type, credential_level, credential_status, content, encryption_public_key)
@@ -295,7 +289,6 @@ action share_credential($id, $original_credential_id, $issuer, $credential_type,
     VALUES ($original_credential_id, $id);
 }
 
-@kgw(authn='true')
 action edit_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT CASE
@@ -315,7 +308,6 @@ action edit_credential($id, $issuer, $credential_type, $credential_level, $crede
     );
 }
 
-@kgw(authn='true')
 action remove_credential($id) public {
     $has_locked_grants_eth = idos_eth.has_locked_grants(@caller, $id);
     $has_locked_grants_near = idos_near.has_locked_grants(@caller, $id);
@@ -360,7 +352,6 @@ action get_credential_shared ($id) public view {
     WHERE id = $id;
 }
 
-@kgw(authn='true')
 action share_attribute($id, $original_attribute_id, $attribute_key, $value) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
@@ -391,12 +382,11 @@ action add_shared_attribute($original_id, $duplicate_id) public {
     VALUES ($original_id, $duplicate_id);
 }
 
-@kgw(authn='true')
 action add_wallet($id, $address, $public_key, $message, $signature) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     $wallet_type = idos_near.determine_wallet_type($address);
 
-    SELECT CASE WHEN $wallet_type = 'NEAR' AND $public_key IS NULL THEN ERROR('NEAR wallets require a public_key to be given.') END;
+    SELECT CASE WHEN $wallet_type = 'NEAR' AND $public_key::TEXT IS NULL THEN ERROR('NEAR wallets require a public_key to be given.') END;
 
     $valid_near_public_key = idos_near.is_valid_public_key($public_key);
     SELECT CASE WHEN $wallet_type = 'NEAR' AND $valid_near_public_key != 1 THEN ERROR('Invalid or unsupported public key.') END;

--- a/schema.production.kf
+++ b/schema.production.kf
@@ -86,7 +86,7 @@ action delete_delegate_as_owner($address) owner public {
 
 action authorize_delegate() private {
     SELECT CASE
-        WHEN NOT EXISTS(SELECT 1 FROM delegates WHERE address = @caller collate nocase)
+        WHEN NOT EXISTS (SELECT 1 FROM delegates WHERE address = @caller collate nocase)
         THEN ERROR('Unauthorized writer')
     END;
 }
@@ -178,7 +178,7 @@ action add_attribute_as_owner($id, $human_id, $attribute_key, $value) public {
 action edit_attribute($id, $attribute_key, $value) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT CASE
-        WHEN (
+        WHEN EXISTS (
             SELECT 1 from human_attributes AS ha
                 INNER JOIN shared_human_attributes AS sha on ha.id = sha.duplicate_id
                 WHERE ha.id = $id
@@ -225,7 +225,7 @@ action remove_wallet($id) public {
 }
 
 action has_profile($address) public view {
-    SELECT EXISTS(
+    SELECT EXISTS (
         SELECT 1 FROM wallets WHERE address=$address COLLATE NOCASE
     ) AS has_profile;
 }
@@ -292,7 +292,7 @@ action share_credential($id, $original_credential_id, $issuer, $credential_type,
 action edit_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT CASE
-        WHEN (
+        WHEN EXISTS (
             SELECT 1 from credentials AS c
                 INNER JOIN shared_credentials AS sc on c.id = sc.duplicate_id
                 WHERE c.id = $id

--- a/schema.production.kf
+++ b/schema.production.kf
@@ -102,7 +102,7 @@ action upsert_wallet_as_owner($id, $human_id, $address, $public_key, $wallet_typ
 
     INSERT INTO humans (id) VALUES ($human_id) ON CONFLICT(id) DO NOTHING;
 
-    SELECT CASE WHEN $wallet_type = 'NEAR' AND $public_key IS NULL THEN ERROR('NEAR wallets require a public_key to be given.') END;
+    SELECT CASE WHEN $wallet_type = 'NEAR' AND $public_key::TEXT IS NULL THEN ERROR('NEAR wallets require a public_key to be given.') END;
 
     $valid_near_public_key = idos_near.is_valid_public_key($public_key);
     SELECT CASE WHEN $wallet_type = 'NEAR' AND $valid_near_public_key != 1 THEN ERROR('Invalid or unsupported public key.') END;
@@ -150,7 +150,6 @@ action get_attributes() public view {
     );
 }
 
-@kgw(authn='true')
 action add_attribute($id, $attribute_key, $value) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
@@ -176,7 +175,6 @@ action add_attribute_as_owner($id, $human_id, $attribute_key, $value) public {
     );
 }
 
-@kgw(authn='true')
 action edit_attribute($id, $attribute_key, $value) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT CASE
@@ -196,7 +194,6 @@ action edit_attribute($id, $attribute_key, $value) public {
     );
 }
 
-@kgw(authn='true')
 action remove_attribute($id) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     DELETE FROM human_attributes
@@ -219,7 +216,6 @@ action get_wallets() public view {
     );
 }
 
-@kgw(authn='true')
 action remove_wallet($id) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     DELETE FROM wallets
@@ -256,7 +252,6 @@ action get_credentials() public view {
     );
 }
 
-@kgw(authn='true')
 action add_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     INSERT INTO credentials (id, human_id, issuer, credential_type, credential_level, credential_status, content, encryption_public_key)
@@ -274,7 +269,6 @@ action add_credential($id, $issuer, $credential_type, $credential_level, $creden
     );
 }
 
-@kgw(authn='true')
 action share_credential($id, $original_credential_id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     INSERT INTO credentials (id, human_id, issuer, credential_type, credential_level, credential_status, content, encryption_public_key)
@@ -295,7 +289,6 @@ action share_credential($id, $original_credential_id, $issuer, $credential_type,
     VALUES ($original_credential_id, $id);
 }
 
-@kgw(authn='true')
 action edit_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT CASE
@@ -315,7 +308,6 @@ action edit_credential($id, $issuer, $credential_type, $credential_level, $crede
     );
 }
 
-@kgw(authn='true')
 action remove_credential($id) public {
     $has_locked_grants_eth = idos_eth.has_locked_grants(@caller, $id);
     $has_locked_grants_near = idos_near.has_locked_grants(@caller, $id);
@@ -360,7 +352,6 @@ action get_credential_shared ($id) public view {
     WHERE id = $id;
 }
 
-@kgw(authn='true')
 action share_attribute($id, $original_attribute_id, $attribute_key, $value) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
@@ -391,12 +382,11 @@ action add_shared_attribute($original_id, $duplicate_id) public {
     VALUES ($original_id, $duplicate_id);
 }
 
-@kgw(authn='true')
 action add_wallet($id, $address, $public_key, $message, $signature) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     $wallet_type = idos_near.determine_wallet_type($address);
 
-    SELECT CASE WHEN $wallet_type = 'NEAR' AND $public_key IS NULL THEN ERROR('NEAR wallets require a public_key to be given.') END;
+    SELECT CASE WHEN $wallet_type = 'NEAR' AND $public_key::TEXT IS NULL THEN ERROR('NEAR wallets require a public_key to be given.') END;
 
     $valid_near_public_key = idos_near.is_valid_public_key($public_key);
     SELECT CASE WHEN $wallet_type = 'NEAR' AND $valid_near_public_key != 1 THEN ERROR('Invalid or unsupported public key.') END;

--- a/schema.staging.kf
+++ b/schema.staging.kf
@@ -86,7 +86,7 @@ action delete_delegate_as_owner($address) owner public {
 
 action authorize_delegate() private {
     SELECT CASE
-        WHEN NOT EXISTS(SELECT 1 FROM delegates WHERE address = @caller collate nocase)
+        WHEN NOT EXISTS (SELECT 1 FROM delegates WHERE address = @caller collate nocase)
         THEN ERROR('Unauthorized writer')
     END;
 }
@@ -178,7 +178,7 @@ action add_attribute_as_owner($id, $human_id, $attribute_key, $value) public {
 action edit_attribute($id, $attribute_key, $value) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT CASE
-        WHEN (
+        WHEN EXISTS (
             SELECT 1 from human_attributes AS ha
                 INNER JOIN shared_human_attributes AS sha on ha.id = sha.duplicate_id
                 WHERE ha.id = $id
@@ -225,7 +225,7 @@ action remove_wallet($id) public {
 }
 
 action has_profile($address) public view {
-    SELECT EXISTS(
+    SELECT EXISTS (
         SELECT 1 FROM wallets WHERE address=$address COLLATE NOCASE
     ) AS has_profile;
 }
@@ -292,7 +292,7 @@ action share_credential($id, $original_credential_id, $issuer, $credential_type,
 action edit_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT CASE
-        WHEN (
+        WHEN EXISTS (
             SELECT 1 from credentials AS c
                 INNER JOIN shared_credentials AS sc on c.id = sc.duplicate_id
                 WHERE c.id = $id

--- a/schema.staging.kf
+++ b/schema.staging.kf
@@ -102,7 +102,7 @@ action upsert_wallet_as_owner($id, $human_id, $address, $public_key, $wallet_typ
 
     INSERT INTO humans (id) VALUES ($human_id) ON CONFLICT(id) DO NOTHING;
 
-    SELECT CASE WHEN $wallet_type = 'NEAR' AND $public_key IS NULL THEN ERROR('NEAR wallets require a public_key to be given.') END;
+    SELECT CASE WHEN $wallet_type = 'NEAR' AND $public_key::TEXT IS NULL THEN ERROR('NEAR wallets require a public_key to be given.') END;
 
     $valid_near_public_key = idos_near.is_valid_public_key($public_key);
     SELECT CASE WHEN $wallet_type = 'NEAR' AND $valid_near_public_key != 1 THEN ERROR('Invalid or unsupported public key.') END;
@@ -150,7 +150,6 @@ action get_attributes() public view {
     );
 }
 
-@kgw(authn='true')
 action add_attribute($id, $attribute_key, $value) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
@@ -176,7 +175,6 @@ action add_attribute_as_owner($id, $human_id, $attribute_key, $value) public {
     );
 }
 
-@kgw(authn='true')
 action edit_attribute($id, $attribute_key, $value) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT CASE
@@ -196,7 +194,6 @@ action edit_attribute($id, $attribute_key, $value) public {
     );
 }
 
-@kgw(authn='true')
 action remove_attribute($id) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     DELETE FROM human_attributes
@@ -219,7 +216,6 @@ action get_wallets() public view {
     );
 }
 
-@kgw(authn='true')
 action remove_wallet($id) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     DELETE FROM wallets
@@ -256,7 +252,6 @@ action get_credentials() public view {
     );
 }
 
-@kgw(authn='true')
 action add_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     INSERT INTO credentials (id, human_id, issuer, credential_type, credential_level, credential_status, content, encryption_public_key)
@@ -274,7 +269,6 @@ action add_credential($id, $issuer, $credential_type, $credential_level, $creden
     );
 }
 
-@kgw(authn='true')
 action share_credential($id, $original_credential_id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     INSERT INTO credentials (id, human_id, issuer, credential_type, credential_level, credential_status, content, encryption_public_key)
@@ -295,7 +289,6 @@ action share_credential($id, $original_credential_id, $issuer, $credential_type,
     VALUES ($original_credential_id, $id);
 }
 
-@kgw(authn='true')
 action edit_credential($id, $issuer, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT CASE
@@ -315,7 +308,6 @@ action edit_credential($id, $issuer, $credential_type, $credential_level, $crede
     );
 }
 
-@kgw(authn='true')
 action remove_credential($id) public {
     $has_locked_grants_eth = idos_eth.has_locked_grants(@caller, $id);
     $has_locked_grants_near = idos_near.has_locked_grants(@caller, $id);
@@ -360,7 +352,6 @@ action get_credential_shared ($id) public view {
     WHERE id = $id;
 }
 
-@kgw(authn='true')
 action share_attribute($id, $original_attribute_id, $attribute_key, $value) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
@@ -391,12 +382,11 @@ action add_shared_attribute($original_id, $duplicate_id) public {
     VALUES ($original_id, $duplicate_id);
 }
 
-@kgw(authn='true')
 action add_wallet($id, $address, $public_key, $message, $signature) public {
     $converted = idos_near.implicit_address_to_public_key(@caller);
     $wallet_type = idos_near.determine_wallet_type($address);
 
-    SELECT CASE WHEN $wallet_type = 'NEAR' AND $public_key IS NULL THEN ERROR('NEAR wallets require a public_key to be given.') END;
+    SELECT CASE WHEN $wallet_type = 'NEAR' AND $public_key::TEXT IS NULL THEN ERROR('NEAR wallets require a public_key to be given.') END;
 
     $valid_near_public_key = idos_near.is_valid_public_key($public_key);
     SELECT CASE WHEN $wallet_type = 'NEAR' AND $valid_near_public_key != 1 THEN ERROR('Invalid or unsupported public key.') END;


### PR DESCRIPTION
One of the main changes was made in an other PR. They are about type coercion `$public_key::TEXT IS NULL `
So there's only a cosmetic improvement left in this PR - removing unnecessary `@kgw(authn='true')` annotations for mutate actions. Any `mutate` action requires authorization but `read` actions don't. So that is why we keep this annotations only for `read` actions.

Also in this PR is fixed wrong predicate usage.