### PR TITLE
Do not fail when when insert human

### DIFF
--- a/schema.development.kf
+++ b/schema.development.kf
@@ -94,7 +94,7 @@ action authorize_delegate() private {
 action add_human_as_owner($id) public {
     authorize_delegate();
 
-    INSERT INTO humans (id) VALUES ($id);
+    INSERT INTO humans (id) VALUES ($id) ON CONFLICT(id) DO NOTHING;
 }
 
 action upsert_wallet_as_owner($id, $human_id, $address, $public_key, $wallet_type, $message, $signature) public {

--- a/schema.playground.kf
+++ b/schema.playground.kf
@@ -94,7 +94,7 @@ action authorize_delegate() private {
 action add_human_as_owner($id) public {
     authorize_delegate();
 
-    INSERT INTO humans (id) VALUES ($id);
+    INSERT INTO humans (id) VALUES ($id) ON CONFLICT(id) DO NOTHING;
 }
 
 action upsert_wallet_as_owner($id, $human_id, $address, $public_key, $wallet_type, $message, $signature) public {

--- a/schema.production.kf
+++ b/schema.production.kf
@@ -94,7 +94,7 @@ action authorize_delegate() private {
 action add_human_as_owner($id) public {
     authorize_delegate();
 
-    INSERT INTO humans (id) VALUES ($id);
+    INSERT INTO humans (id) VALUES ($id) ON CONFLICT(id) DO NOTHING;
 }
 
 action upsert_wallet_as_owner($id, $human_id, $address, $public_key, $wallet_type, $message, $signature) public {

--- a/schema.staging.kf
+++ b/schema.staging.kf
@@ -94,7 +94,7 @@ action authorize_delegate() private {
 action add_human_as_owner($id) public {
     authorize_delegate();
 
-    INSERT INTO humans (id) VALUES ($id);
+    INSERT INTO humans (id) VALUES ($id) ON CONFLICT(id) DO NOTHING;
 }
 
 action upsert_wallet_as_owner($id, $human_id, $address, $public_key, $wallet_type, $message, $signature) public {


### PR DESCRIPTION
Concurrent mechanism of processing idos_kwil queue may end up to the error:
```ruby
ERROR: duplicate key value violates unique constraint "humans_pkey" (SQLSTATE 23505) (Services::Idos::HumanNotAdded)
```
To avoid that we should do nothing in case of uniq `id` conflict when inserting.