### PR TITLE
Fix shared credential retrieval authorization

### DIFF
--- a/schema.development.kf
+++ b/schema.development.kf
@@ -575,7 +575,7 @@ procedure has_locked_grants($id uuid) public view returns (has bool) {
 // It needs to be done at this moment because of later defining data can change (original credential deleted, owner wallet or profile removed etc.)
 procedure define_ag_status_as_owner($ag_owner text, $ag_grantee text, $data_id uuid) public view owner returns (status text) {
     if !credential_exist($data_id) {
-        return 'the credential does not exist';
+        return 'invalid_data_id_not_found';
     }
 
     $data_id_is_duplicate := false;
@@ -583,7 +583,7 @@ procedure define_ag_status_as_owner($ag_owner text, $ag_grantee text, $data_id u
         $data_id_is_duplicate := true;
     }
     if !$data_id_is_duplicate {
-        return 'data_id is original credential';
+        return 'invalid_data_id_is_not_a_duplicate';
     }
 
     for $row2 in SELECT 1 FROM wallets
@@ -595,7 +595,7 @@ procedure define_ag_status_as_owner($ag_owner text, $ag_grantee text, $data_id u
             return 'valid';
         }
 
-    return 'the ag owner was not issued the credential';
+    return 'invalid_ag_owner_does_not_match_original_credential_owner';
 }
 
 

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -477,6 +477,15 @@ procedure get_credential_shared ($id uuid) public view returns table (id uuid, h
         issuer, inserter FROM credentials WHERE id = $id;
 }
 
+@kgw(authn='true')
+procedure list_ag_statuses($data_id text) public view returns table (ag_owner text, ag_grantee text, locked_until int, status text) {
+    return
+        SELECT ag_owner, ag_grantee, locked_until, status
+        FROM access_grants
+        WHERE data_id = $data_id
+          AND ag_grantee = @caller;
+}
+
 procedure credential_exist($id uuid) private view returns (credential_exist bool) {
     for $row in SELECT 1 FROM credentials WHERE id = $id {
         return true;

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -429,10 +429,7 @@ action share_credential_through_dag (
 @kgw(authn='true')
 procedure credential_exist_as_inserter($id uuid) public view returns (credential_exist bool) {
     get_inserter();
-    for $row in SELECT 1 FROM credentials WHERE id = $id {
-        return true;
-    }
-    return false;
+    return credential_exist($id);
 }
 
 // TODO: change to procedure
@@ -451,12 +448,27 @@ action get_credential_owned ($id) public view {
 @kgw(authn='true')
 procedure get_credential_shared ($id uuid) public view returns table (id uuid, human_id uuid, credential_type text,
     credential_level text, credential_status text, content text, encryption_public_key text, issuer text, inserter text) {
+    if !credential_exist($id) {
+        error('shared credential does not exist');
+    }
+
+    if !data_granted_to_grantee($id, @caller) {
+        error('shared credential is not shared with the caller');
+    }
+
     if !has_grants($id) {
-        error('caller does not have access');
+        error('the credential has grant but the owner does not match');
     }
 
     return SELECT id, human_id, credential_type, credential_level, credential_status, content, encryption_public_key,
         issuer, inserter FROM credentials WHERE id = $id;
+}
+
+procedure credential_exist($id uuid) private view returns (credential_exist bool) {
+    for $row in SELECT 1 FROM credentials WHERE id = $id {
+        return true;
+    }
+    return false;
 }
 
 
@@ -539,8 +551,26 @@ procedure share_attribute($id uuid, $original_attribute_id uuid, $attribute_key 
 // ACCEESS GRANTS ACTIONS
 
 @kgw(authn='true')
-procedure has_grants($id uuid) public view returns (granted bool) {
-    for $row in SELECT 1 FROM access_grants WHERE data_id = $id AND ag_grantee = @caller COLLATE NOCASE LIMIT 1 {
+procedure has_grants($id uuid) public view returns (has_grants bool) {
+    for $row in SELECT 1 FROM access_grants
+        JOIN credentials ON access_grants.data_id = credentials.id
+        JOIN wallets ON credentials.human_id = wallets.human_id
+        WHERE access_grants.data_id = $id
+        AND access_grants.ag_grantee = @caller
+        AND ((wallets.address = access_grants.ag_owner AND wallets.wallet_type = 'EVM')
+            OR (wallets.public_key = access_grants.ag_owner AND wallets.wallet_type = 'NEAR'))
+
+        LIMIT 1 {
+        return true;
+    }
+    return false;
+}
+
+procedure data_granted_to_grantee($data_id uuid, $grantee text) private view returns (granted bool) {
+    for $row in SELECT 1 FROM access_grants
+    WHERE data_id = $data_id
+        AND ag_grantee = $grantee COLLATE NOCASE
+    LIMIT 1 {
         return true;
     }
     return false;

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -48,6 +48,7 @@ table shared_credentials {
     original_id uuid notnull,
     duplicate_id uuid notnull,
     #primary_key primary(original_id, duplicate_id),
+    #shared_credentials_duplicate_id index(duplicate_id),
     foreign_key (original_id) references credentials(id) on_delete cascade,
     foreign_key (duplicate_id) references credentials(id) on_delete cascade
 }
@@ -568,6 +569,33 @@ procedure has_locked_grants($id uuid) public view returns (has bool) {
         return true;
     }
     return false;
+}
+
+// This procedure is used in an oracle resolution to determine the status of a AG at the moment of adding it into idOS
+// It needs to be done at this moment because of later defining data can change (original credential deleted, owner wallet or profile removed etc.)
+procedure define_ag_status_as_owner($ag_owner text, $ag_grantee text, $data_id uuid) public view owner returns (status text) {
+    if !credential_exist($data_id) {
+        return 'the credential does not exist';
+    }
+
+    $data_id_is_duplicate := false;
+    for $row in SELECT 1 FROM shared_credentials WHERE duplicate_id = $data_id LIMIT 1 {
+        $data_id_is_duplicate := true;
+    }
+    if !$data_id_is_duplicate {
+        return 'data_id is original credential';
+    }
+
+    for $row2 in SELECT 1 FROM wallets
+        INNER JOIN credentials ON credentials.human_id = wallets.human_id
+        WHERE credentials.id = $data_id
+        AND ((wallets.address = $ag_owner COLLATE NOCASE AND wallets.wallet_type = 'EVM')
+            OR (wallets.public_key = $ag_owner COLLATE NOCASE AND wallets.wallet_type = 'NEAR'))
+        LIMIT 1 {
+            return 'valid';
+        }
+
+    return 'the ag owner was not issued the credential';
 }
 
 

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -470,7 +470,7 @@ procedure get_credential_shared ($id uuid) public view returns table (id uuid, h
     }
 
     if !$grant_valid {
-        error('the credential has no valid access grant');
+        error('the credential has no valid access grant; for more details, call list_ag_statuses');
     }
 
     return SELECT id, human_id, credential_type, credential_level, credential_status, content, encryption_public_key,

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -91,6 +91,7 @@ table access_grants {
     tx_hash text,
     block_hash text,
     height int,
+    status text,
     #access_grants_data_id_grantee index(data_id, ag_grantee),
     #access_grants_data_id_owner index(data_id, ag_owner)
 }
@@ -448,16 +449,27 @@ action get_credential_owned ($id) public view {
 @kgw(authn='true')
 procedure get_credential_shared ($id uuid) public view returns table (id uuid, human_id uuid, credential_type text,
     credential_level text, credential_status text, content text, encryption_public_key text, issuer text, inserter text) {
-    if !shared_credential_exist($id) {
-        error('shared credential does not exist');
+    if !credential_exist($id) {
+        error('the credential does not exist');
     }
 
-    if !data_granted_to_grantee($id, @caller) {
-        error('shared credential is not shared with the caller');
+    $granted bool := false;
+    $grant_valid bool := false;
+
+    for $row in SELECT status FROM access_grants WHERE data_id = $id::TEXT AND ag_grantee = @caller COLLATE NOCASE {
+        $granted := true;
+        if $row.status == 'valid' {
+            $grant_valid := true;
+            break;
+        }
     }
 
-    if !has_grants($id) {
-        error('the credential has grant but the owner does not match');
+    if !$granted {
+        error('the credential is not shared with the caller');
+    }
+
+    if !$grant_valid {
+        error('the credential has no valid access grant');
     }
 
     return SELECT id, human_id, credential_type, credential_level, credential_status, content, encryption_public_key,
@@ -466,13 +478,6 @@ procedure get_credential_shared ($id uuid) public view returns table (id uuid, h
 
 procedure credential_exist($id uuid) private view returns (credential_exist bool) {
     for $row in SELECT 1 FROM credentials WHERE id = $id {
-        return true;
-    }
-    return false;
-}
-
-procedure shared_credential_exist($id uuid) private view returns (credential_exist bool) {
-    for $row in SELECT 1 FROM shared_credentials WHERE duplicate_id = $id LIMIT 1 {
         return true;
     }
     return false;
@@ -556,32 +561,6 @@ procedure share_attribute($id uuid, $original_attribute_id uuid, $attribute_key 
 
 
 // ACCEESS GRANTS ACTIONS
-
-@kgw(authn='true')
-procedure has_grants($id uuid) public view returns (has_grants bool) {
-    for $row in SELECT 1 FROM access_grants
-        INNER JOIN credentials ON access_grants.data_id = credentials.id
-        INNER JOIN wallets ON credentials.human_id = wallets.human_id
-        WHERE access_grants.data_id = $id
-        AND access_grants.ag_grantee = @caller COLLATE NOCASE
-        AND ((wallets.address = access_grants.ag_owner COLLATE NOCASE AND wallets.wallet_type = 'EVM')
-            OR (wallets.public_key = access_grants.ag_owner COLLATE NOCASE AND wallets.wallet_type = 'NEAR'))
-
-        LIMIT 1 {
-        return true;
-    }
-    return false;
-}
-
-procedure data_granted_to_grantee($data_id uuid, $grantee text) private view returns (granted bool) {
-    for $row in SELECT 1 FROM access_grants
-    WHERE data_id = $data_id
-        AND ag_grantee = $grantee COLLATE NOCASE
-    LIMIT 1 {
-        return true;
-    }
-    return false;
-}
 
 @kgw(authn='true')
 procedure has_locked_grants($id uuid) public view returns (has bool) {

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -448,7 +448,7 @@ action get_credential_owned ($id) public view {
 @kgw(authn='true')
 procedure get_credential_shared ($id uuid) public view returns table (id uuid, human_id uuid, credential_type text,
     credential_level text, credential_status text, content text, encryption_public_key text, issuer text, inserter text) {
-    if !credential_exist($id) {
+    if !shared_credential_exist($id) {
         error('shared credential does not exist');
     }
 
@@ -466,6 +466,13 @@ procedure get_credential_shared ($id uuid) public view returns table (id uuid, h
 
 procedure credential_exist($id uuid) private view returns (credential_exist bool) {
     for $row in SELECT 1 FROM credentials WHERE id = $id {
+        return true;
+    }
+    return false;
+}
+
+procedure shared_credential_exist($id uuid) private view returns (credential_exist bool) {
+    for $row in SELECT 1 FROM shared_credentials WHERE duplicate_id = $id LIMIT 1 {
         return true;
     }
     return false;
@@ -553,12 +560,12 @@ procedure share_attribute($id uuid, $original_attribute_id uuid, $attribute_key 
 @kgw(authn='true')
 procedure has_grants($id uuid) public view returns (has_grants bool) {
     for $row in SELECT 1 FROM access_grants
-        JOIN credentials ON access_grants.data_id = credentials.id
-        JOIN wallets ON credentials.human_id = wallets.human_id
+        INNER JOIN credentials ON access_grants.data_id = credentials.id
+        INNER JOIN wallets ON credentials.human_id = wallets.human_id
         WHERE access_grants.data_id = $id
-        AND access_grants.ag_grantee = @caller
-        AND ((wallets.address = access_grants.ag_owner AND wallets.wallet_type = 'EVM')
-            OR (wallets.public_key = access_grants.ag_owner AND wallets.wallet_type = 'NEAR'))
+        AND access_grants.ag_grantee = @caller COLLATE NOCASE
+        AND ((wallets.address = access_grants.ag_owner COLLATE NOCASE AND wallets.wallet_type = 'EVM')
+            OR (wallets.public_key = access_grants.ag_owner COLLATE NOCASE AND wallets.wallet_type = 'NEAR'))
 
         LIMIT 1 {
         return true;


### PR DESCRIPTION
When a grantee signs a request to retrieve a shared credential from the idOS, we should ensure that they have an access grant:
- for the requested credential ID (data ID)
- created by the credential’s human (owner)

We are currently not doing the second check. This means it’s possible for a grantee to create an access grant with themselves as the owner for any existing credential ID, and then successfully retrieved that credential from the idOS.
While this issue is made less problematic due to credential encryption, it’s still an embarrassing security hole we need to patch.

This PR checks checks if AG's owner exists as wallet for human which owner of the shared credential.