### PR TITLE
Access grants for writing data

### DIFF
--- a/schema.development.kf
+++ b/schema.development.kf
@@ -33,9 +33,9 @@ table credentials {
     human_id uuid notnull,
     credential_type text notnull,
     credential_level text,
-    credential_status text,
+    credential_status text, // idOS credential's status, not VC status (VC statuses are managed inside VC content and revocations mechanism)
     content text notnull,
-    encryption_public_key text notnull,
+    encryption_public_key text notnull, // public key of encryptor
     issuer text notnull,
     inserter text,
     #credentials_human_id index(human_id),
@@ -90,27 +90,30 @@ table external_access_grants {
     tx_hash text,
     block_hash text,
     height int,
-    status text,
+    // data_id in contract can be any data, but idOS expects uuid of a credential, so we need a ststus field to makr validity of the access grant
+    status text, // valid, invalid_by_reason, ...
     #external_ag_data_id_grantee index(data_id, ag_grantee),
     #external_ag_data_id_owner index(data_id, ag_owner)
 }
 
+// A human/user gives a grant to write data (create a credential, share the credemtial) on his behalf to some issuer
 table write_grants {
     id uuid primary,
-    wg_owner text notnull,
-    wg_grantee text notnull,
-    wg_owner_human_id uuid notnull,
+    wg_owner text notnull, // human wallet/pk
+    wg_grantee text notnull, // issuer wallet/pk
+    wg_owner_human_id uuid notnull, // human's id, to be sure we will find the human if the owner's wallet will be deleted
     #write_grants_human_id_grantee unique(wg_owner_human_id, wg_grantee)
 }
 
+// internal access grants can be granted if such permission is in write_grants
 table internal_access_grants {
     id uuid primary,
     ag_owner text notnull,
     ag_grantee text notnull,
     data_id text notnull,
     locked_until int notnull,
-    wg_id uuid,
-    foreign_key (wg_id) references write_grants(id) on_delete set_null // TODO Maybe `set_null` is not the right decision?
+    write_grant_id uuid,
+    foreign_key (write_grant_id) references write_grants(id) on_delete set null
 }
 
 table configs {
@@ -785,6 +788,32 @@ procedure insert_shared_attr_as_owner($original_id uuid, $duplicate_id uuid) own
     VALUES ($original_id, $duplicate_id);
 }
 
+// Some entities no need special actions because main actions do the same
+// inserters:  add_inserter_as_owner
+// delegates: add_delegate_as_owner
+// configs: upsert_config_as_owner
+
+procedure insert_external_ags_as_owner($id uuid, $ag_owner text, $ag_grantee text, $data_id text,
+    $locked_until int, $ag_chain text, $tx_hash text, $block_hash text, $height int, $status text
+    ) owner public {
+    INSERT INTO external_access_grants (id, ag_owner, ag_grantee, data_id, locked_until, ag_chain,
+        tx_hash, block_hash, height, status)
+    VALUES ($id, $ag_owner, $ag_grantee, $data_id, $locked_until, $ag_chain,
+        $tx_hash, $block_hash, $height, $status);
+}
+
+procedure insert_internal_ags_as_owner($id uuid, $ag_owner text, $ag_grantee text, $data_id text,
+    $locked_until int, $write_grant_id uuid) owner public {
+    INSERT INTO internal_access_grants (id, ag_owner, ag_grantee, data_id, locked_until, write_grant_id)
+    VALUES ($id, $ag_owner, $ag_grantee, $data_id, $locked_until, $write_grant_id);
+}
+
+procedure insert_write_grants_as_owner($id uuid, $wg_owner text, $wg_grantee text, $wg_owner_human_id uuid) owner public {
+    INSERT INTO write_grants (id, wg_owner, wg_grantee, wg_owner_human_id)
+    VALUES ($id, $wg_owner, $wg_grantee, $wg_owner_human_id);
+}
+
+
 // ACTIONS FOR IN-SCHEMA DATA MIGRATION
 
 procedure all_humans_as_owner() public view owner returns table (id uuid, current_public_key text, inserter text){
@@ -823,9 +852,19 @@ procedure all_delegates_as_owner() public view owner returns table (address text
     return SELECT address, inserter_id FROM delegates;
 }
 
-procedure all_grants_as_owner() public view owner returns table (id uuid, ag_owner text, ag_grantee text,
+procedure all_external_grants_as_owner() public view owner returns table (id uuid, ag_owner text, ag_grantee text,
     data_id text, locked_until int, ag_chain text, tx_hash text, height int, block_hash text) {
     return SELECT id, ag_owner, ag_grantee, data_id, locked_until, ag_chain, tx_hash, height, block_hash FROM external_access_grants;
+}
+
+procedure all_internal_grants_as_owner() public view owner returns table (id uuid, ag_owner text, ag_grantee text,
+    data_id text, locked_until int, write_grant_id uuid) {
+    return SELECT id, ag_owner, ag_grantee, data_id, locked_until, write_grant_id FROM internal_access_grants;
+}
+
+procedure all_write_grants_as_owner() public view owner returns table (id uuid, wg_owner text, wg_grantee text,
+    wg_owner_human_id uuid) {
+    return SELECT id, wg_owner, wg_grantee, wg_owner_human_id FROM write_grants;
 }
 
 procedure all_configs_as_owner() public view owner returns table (config_key text, value text) {

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -757,6 +757,19 @@ procedure revoke_internal_access_grant ($id uuid) public {
 }
 
 // TODO write findGrants_internal_grants, so that both owners and grantees can list the AGs for them.
+procedure get_internal_ag_owned () public view returns table (id uuid, ag_owner_human_id uuid,
+    ag_grantee text, data_id uuid, locked_until int, write_grant_id uuid) {
+    return SELECT id, ag_owner_human_id, ag_grantee, data_id, locked_until, write_grant_id FROM internal_access_grants
+        WHERE ag_owner_human_id = (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = @caller));
+}
+
+procedure get_internal_ag_granted () public view returns table (id uuid, ag_owner_human_id uuid,
+    ag_grantee text, data_id uuid, locked_until int) {
+    return SELECT id, ag_owner_human_id, ag_grantee, data_id, locked_until FROM internal_access_grants
+        WHERE ag_grantee =  @caller;
+}
+
 
 // OTHER ACTIONS
 

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -7,8 +7,6 @@ use idos as idos;
 
 // TABLES
 
-// TABLES
-
 table humans {
     id uuid primary,
     current_public_key text notnull,

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -475,15 +475,6 @@ procedure get_credential_shared ($id uuid) public view returns table (id uuid, h
         issuer, inserter FROM credentials WHERE id = $id;
 }
 
-@kgw(authn='true')
-procedure list_ag_statuses($data_id text) public view returns table (ag_owner text, ag_grantee text, locked_until int, status text) {
-    return
-        SELECT ag_owner, ag_grantee, locked_until, status
-        FROM access_grants
-        WHERE data_id = $data_id
-          AND ag_grantee = @caller;
-}
-
 procedure credential_exist($id uuid) private view returns (credential_exist bool) {
     for $row in SELECT 1 FROM credentials WHERE id = $id {
         return true;
@@ -571,8 +562,21 @@ procedure share_attribute($id uuid, $original_attribute_id uuid, $attribute_key 
 // ACCEESS GRANTS ACTIONS
 
 @kgw(authn='true')
+procedure list_ag_statuses($data_id text) public view returns table (ag_owner text, ag_grantee text, locked_until int, status text) {
+    return
+        SELECT ag_owner, ag_grantee, locked_until, status
+        FROM access_grants
+        WHERE data_id = $data_id
+          AND ag_grantee = @caller;
+}
+
+@kgw(authn='true')
 procedure has_locked_grants($id uuid) public view returns (has bool) {
-    for $row in SELECT 1 FROM access_grants WHERE data_id = $id::TEXT AND ag_owner = @caller COLLATE NOCASE AND locked_until >= @block_timestamp LIMIT 1 {
+    for $row in SELECT 1 FROM access_grants
+            WHERE data_id = $id::TEXT
+            AND ag_owner = @caller COLLATE NOCASE
+            AND status = 'valid'
+            AND locked_until >= @block_timestamp LIMIT 1 {
         return true;
     }
     return false;

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -90,7 +90,7 @@ table external_access_grants {
     tx_hash text,
     block_hash text,
     height int,
-    // data_id in contract can be any data, but idOS expects uuid of a credential, so we need a ststus field to makr validity of the access grant
+    // data_id in contract can be any data, but idOS expects uuid of a credential, so we need a ststus field to mark validity of the access grant
     status text, // valid, invalid_by_reason, ...
     #external_ag_data_id_grantee index(data_id, ag_grantee),
     #external_ag_data_id_owner index(data_id, ag_owner)
@@ -738,11 +738,6 @@ procedure remove_write_grant($wg_grantee text) public {
         WHERE wg_grantee = $wg_grantee COLLATE NOCASE
         AND wg_owner_human_id = (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
             OR (wallet_type = 'NEAR' AND public_key = @caller));
-}
-
-// Not sure we need this. But at least for testing it is valuable.
-procedure remove_write_grant_as_owner($id uuid) public owner {
-    DELETE FROM write_grants WHERE id = $id;
 }
 
 procedure get_write_grant_id($human_id uuid) private view returns (id uuid) {

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -390,7 +390,7 @@ procedure share_credential(
         $encryption_public_key text,
         $issuer text) public {
 
-    if !credential_belongs_to_human($original_credential_id) {
+    if !credential_belongs_to_caller($original_credential_id) {
         error('The original credential does not belong to the caller');
     }
 
@@ -398,7 +398,15 @@ procedure share_credential(
     INSERT INTO shared_credentials (original_id, duplicate_id) VALUES ($original_credential_id, $id);
 }
 
-procedure credential_belongs_to_human($id uuid) private returns (belongs bool) {
+procedure credential_belongs_to_human($id uuid, $human_id uuid) private returns (belongs bool) {
+    for $row in SELECT 1 from credentials WHERE id = $id AND human_id = $human_id LIMIT 1 {
+        return true;
+    }
+
+    return false;
+}
+
+procedure credential_belongs_to_caller($id uuid) private returns (belongs bool) {
     for $row in SELECT 1 from credentials
         WHERE id = $id
         AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
@@ -446,6 +454,33 @@ action share_credential_through_dag (
 
     INSERT INTO credentials (id, human_id, credential_type, credential_level, credential_status, content, encryption_public_key, issuer, inserter)
         VALUES ($id, $human_id, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key, $issuer, get_inserter_or_null());
+    INSERT INTO shared_credentials (original_id, duplicate_id) VALUES ($original_credential_id, $id);
+}
+
+procedure share_credential_by_write_grant(
+    $id uuid,
+    $human_id uuid,
+    $original_credential_id uuid,
+    $credential_type text,
+    $credential_level text,
+    $credential_status text,
+    $content text,
+    $encryption_public_key text,
+    $issuer text) public {
+
+    // will fail if no WG
+    $wg_id := get_write_grant_id($human_id);
+
+    if !credential_belongs_to_human($original_credential_id, $human_id) {
+        error('the original credential does not belong to the human');
+    }
+
+    // if $wg_id != get_credential_inserter($original_credential_id) {
+    //     error('you can share only original credentials you created');
+    // }
+
+    INSERT INTO credentials (id, human_id, credential_type, credential_level, credential_status, content, encryption_public_key, issuer, inserter)
+        VALUES ($id, $human_id, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key, $issuer, $wg_id::TEXT);
     INSERT INTO shared_credentials (original_id, duplicate_id) VALUES ($original_credential_id, $id);
 }
 

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -675,7 +675,7 @@ procedure list_external_ag_statuses($data_id text) public view returns table (ag
 procedure has_locked_grants($id uuid) public view returns (has bool) {
     for $ext_row in SELECT 1 FROM external_access_grants
             WHERE data_id = $id::TEXT
-            AND ag_owner = @caller COLLATE NOCASE // not shure if this condition necessary as we now have owner validation reflected in status
+            AND ag_owner = @caller COLLATE NOCASE
             AND status = 'valid'
             AND locked_until >= @block_timestamp LIMIT 1 {
         return true;
@@ -683,6 +683,8 @@ procedure has_locked_grants($id uuid) public view returns (has bool) {
 
     for $int_row in SELECT 1 FROM internal_access_grants
             WHERE data_id = $id
+            AND ag_owner_human_id = (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+                OR (wallet_type = 'NEAR' AND public_key = @caller))
             AND locked_until >= @block_timestamp LIMIT 1 {
         return true;
     }

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -90,13 +90,13 @@ table external_access_grants {
     tx_hash text,
     block_hash text,
     height int,
-    // data_id in contract can be any data, but idOS expects uuid of a credential, so we need a ststus field to mark validity of the access grant
+    // data_id in contract can be any data, but idOS expects uuid of a credential, so we need a status field to mark validity of the access grant
     status text, // valid, invalid_by_reason, ...
     #external_ag_data_id_grantee index(data_id, ag_grantee),
     #external_ag_data_id_owner index(data_id, ag_owner)
 }
 
-// A human/user gives a grant to write data (create a credential, share the credemtial) on his behalf to some issuer
+// A human/user gives a grant to write data (create a credential, share the credential) on his behalf to some issuer
 table write_grants {
     id uuid primary,
     wg_owner text notnull, // human wallet/pk
@@ -383,6 +383,10 @@ action edit_credential($id, $credential_type, $credential_level, $credential_sta
 }
 
 procedure remove_credential($id uuid) public {
+    if !credential_belongs_to_caller($id) {
+        error('the credential does not belong to the caller');
+    }
+
     if has_locked_grants($id) {
         error('there are locked grants for this credential');
     }
@@ -391,6 +395,8 @@ procedure remove_credential($id uuid) public {
     AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
         OR (wallet_type = 'NEAR' AND public_key = @caller)
     );
+
+    DELETE FROM internal_access_grants WHERE data_id = $id;
 }
 
 // Do we need this procedure? Can share_credential_through_dag cover all cases?
@@ -660,7 +666,7 @@ procedure share_attribute($id uuid, $original_attribute_id uuid, $attribute_key 
 }
 
 
-// ACCEESS GRANTS ACTIONS
+// EXTERNAL ACCESS GRANTS ACTIONS
 
 @kgw(authn='true')
 procedure list_external_ag_statuses($data_id text) public view returns table (ag_owner text, ag_grantee text, locked_until int, status text) {
@@ -669,27 +675,6 @@ procedure list_external_ag_statuses($data_id text) public view returns table (ag
         FROM external_access_grants
         WHERE data_id = $data_id
           AND ag_grantee = @caller;
-}
-
-@kgw(authn='true')
-procedure has_locked_grants($id uuid) public view returns (has bool) {
-    for $ext_row in SELECT 1 FROM external_access_grants
-            WHERE data_id = $id::TEXT
-            AND ag_owner = @caller COLLATE NOCASE
-            AND status = 'valid'
-            AND locked_until >= @block_timestamp LIMIT 1 {
-        return true;
-    }
-
-    for $int_row in SELECT 1 FROM internal_access_grants
-            WHERE data_id = $id
-            AND ag_owner_human_id = (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-                OR (wallet_type = 'NEAR' AND public_key = @caller))
-            AND locked_until >= @block_timestamp LIMIT 1 {
-        return true;
-    }
-
-    return false;
 }
 
 // This procedure is used in an oracle resolution to determine the status of a AG at the moment of adding it into idOS
@@ -770,6 +755,30 @@ procedure get_internal_ag_granted () public view returns table (id uuid, ag_owne
     ag_grantee text, data_id uuid, locked_until int) {
     return SELECT id, ag_owner_human_id, ag_grantee, data_id, locked_until FROM internal_access_grants
         WHERE ag_grantee =  @caller;
+}
+
+
+// BOTH GRANTS ACTIONS
+
+@kgw(authn='true')
+procedure has_locked_grants($id uuid) public view returns (has bool) {
+    for $ext_row in SELECT 1 FROM external_access_grants
+            WHERE data_id = $id::TEXT
+            AND ag_owner = @caller COLLATE NOCASE
+            AND status = 'valid'
+            AND locked_until >= @block_timestamp LIMIT 1 {
+        return true;
+    }
+
+    for $int_row in SELECT 1 FROM internal_access_grants
+            WHERE data_id = $id
+            AND ag_owner_human_id = (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+                OR (wallet_type = 'NEAR' AND public_key = @caller))
+            AND locked_until >= @block_timestamp LIMIT 1 {
+        return true;
+    }
+
+    return false;
 }
 
 

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -749,7 +749,13 @@ procedure get_write_grant_id($human_id uuid) private view returns (id uuid) {
 
 // INTERNAL ACCESS GRANTS ACTIONS
 
-// TODO write revoke_internal_access_grant (required auth, and it has to be the user)
+procedure revoke_internal_access_grant ($id uuid) public {
+    DELETE FROM internal_access_grants
+    WHERE id = $id
+    AND ag_owner_human_id = (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = @caller));
+}
+
 // TODO write findGrants_internal_grants, so that both owners and grantees can list the AGs for them.
 
 // OTHER ACTIONS

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -1,4 +1,4 @@
-database idos;
+database idos_mig;
 
 // EXTENSION INITIALIZATION
 
@@ -878,16 +878,35 @@ procedure insert_write_grants_as_owner($id uuid, $wg_owner text, $wg_grantee tex
 }
 
 
-// ACTIONS FOR IN-SCHEMA DATA MIGRATION
+// ACTIONS FOR IN-SCHEMA DATA MIGRATION (OWNER)
 
-procedure all_humans_as_owner() public view owner returns table (id uuid, current_public_key text, inserter text){
+procedure all_humans_as_owner() public view owner returns table (id uuid, current_public_key text, inserter text) {
     return SELECT id, current_public_key, inserter FROM humans;
 }
 
+foreign procedure get_all_humans() returns table(id uuid, current_public_key text, inserter text)
+
+procedure migrate_humans($dbid text) public owner {
+    for $row in SELECT id, current_public_key, inserter FROM get_all_humans[$dbid, 'all_humans_as_owner']() {
+        INSERT INTO humans (id, current_public_key, inserter) VALUES ($row.id, $row.current_public_key, $row.inserter);
+    }
+}
+
 procedure all_wallets_as_owner() public view owner returns table (id uuid, human_id uuid, address text, public_key text,
-    wallet_type text, message text, signature text, inserter text) {
+wallet_type text, message text, signature text, inserter text) {
     return SELECT id, human_id, address, public_key, wallet_type, message, signature, inserter FROM wallets;
 }
+
+foreign procedure get_all_wallets() returns table (id uuid, human_id uuid, address text, public_key text,
+wallet_type text, message text, signature text, inserter text)
+
+procedure migrate_wallets($dbid text) public owner {
+    for $row in SELECT id, human_id, address, public_key, wallet_type, message, signature, inserter FROM get_all_wallets[$dbid, 'all_wallets_as_owner']() {
+        INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature, inserter)
+            VALUES ($row.id, $row.human_id, $row.address, $row.public_key, $row.wallet_type, $row.message, $row.signature, $row.inserter);
+    }
+}
+
 
 procedure all_credentials_as_owner() public view owner returns table (id uuid, human_id uuid, credential_type text,
     credential_level text, credential_status text, content text, encryption_public_key text, issuer text, inserter text) {
@@ -895,42 +914,162 @@ procedure all_credentials_as_owner() public view owner returns table (id uuid, h
         issuer, inserter FROM credentials;
 }
 
+foreign procedure get_all_credentials() returns table (id uuid, human_id uuid, credential_type text,
+credential_level text, credential_status text, content text, encryption_public_key text, issuer text, inserter text)
+
+procedure migrate_credentials($dbid text) public owner {
+    for $row in SELECT id, human_id, credential_type, credential_level, credential_status, content,
+        encryption_public_key, issuer, inserter FROM get_all_credentials[$dbid, 'all_credentials_as_owner']() {
+        INSERT INTO credentials (id, human_id, credential_type, credential_level, credential_status, content,
+            encryption_public_key, issuer, inserter)
+        VALUES ($row.id, $row.human_id, $row.credential_type, $row.credential_level, $row.credential_status, $row.content,
+            $row.encryption_public_key, $row.issuer, $row.inserter);
+    }
+}
+
+
 procedure all_shared_credentials_as_owner() public view owner returns table (original_id uuid, duplicate_id uuid) {
     return SELECT original_id, duplicate_id FROM shared_credentials;
 }
+
+foreign procedure get_all_shared_credentials() returns table (original_id uuid, duplicate_id uuid)
+
+procedure migrate_shared_credentials($dbid text) public owner {
+    for $row in SELECT original_id, duplicate_id FROM get_all_shared_credentials[$dbid, 'all_shared_credentials_as_owner']() {
+        INSERT INTO shared_credentials (original_id, duplicate_id) VALUES ($row.original_id, $row.duplicate_id);
+    }
+}
+
 
 procedure all_human_attributes_as_owner() public view owner returns table (id uuid, human_id uuid, attribute_key text,
     value text, inserter text) {
     return SELECT id, human_id, attribute_key, value, inserter FROM human_attributes;
 }
 
+foreign procedure get_all_human_attributes() returns table (id uuid, human_id uuid, attribute_key text, value text, inserter text)
+
+procedure migrate_human_attributes($dbid text) public owner {
+    for $row in SELECT id, human_id, attribute_key, value, inserter FROM get_all_human_attributes[$dbid, 'all_human_attributes_as_owner']() {
+        INSERT INTO human_attributes (id, human_id, attribute_key, value, inserter)
+        VALUES ($row.id, $row.human_id, $row.attribute_key, $row.value, $row.inserter);
+    }
+}
+
+
 procedure all_shared_human_attrs_as_owner() public view owner returns table (original_id uuid, duplicate_id uuid) {
     return SELECT original_id, duplicate_id FROM shared_human_attributes;
 }
+
+foreign procedure get_all_shared_human_attrs() returns table (original_id uuid, duplicate_id uuid)
+
+procedure migrate_shared_human_attrs($dbid text) public owner {
+    for $row in SELECT original_id, duplicate_id FROM get_all_shared_human_attrs[$dbid, 'all_shared_human_attrs_as_owner']() {
+        INSERT INTO shared_human_attributes (original_id, duplicate_id) VALUES ($row.original_id, $row.duplicate_id);
+    }
+}
+
 
 procedure all_inserters_as_owner() public view owner returns table (id uuid, name text) {
     return SELECT id, name FROM inserters;
 }
 
+foreign procedure get_all_inserters() returns table (id uuid, name text)
+
+procedure migrate_inserters($dbid text) public owner {
+    for $row in SELECT id, name FROM get_all_inserters[$dbid, 'all_inserters_as_owner']() {
+        INSERT INTO inserters (id, name) VALUES ($row.id, $row.name);
+    }
+}
+
+
 procedure all_delegates_as_owner() public view owner returns table (address text, inserter_id uuid) {
     return SELECT address, inserter_id FROM delegates;
 }
+
+foreign procedure get_all_delegates() returns table (address text, inserter_id uuid)
+
+procedure migrate_delegates($dbid text) public owner {
+    for $row in SELECT address, inserter_id FROM get_all_delegates[$dbid, 'all_delegates_as_owner']() {
+        INSERT INTO delegates (address, inserter_id) VALUES ($row.address, $row.inserter_id);
+    }
+}
+
 
 procedure all_external_grants_as_owner() public view owner returns table (id uuid, ag_owner text, ag_grantee text,
     data_id text, locked_until int, ag_chain text, tx_hash text, height int, block_hash text) {
     return SELECT id, ag_owner, ag_grantee, data_id, locked_until, ag_chain, tx_hash, height, block_hash FROM external_access_grants;
 }
 
+foreign procedure get_all_external_grants() returns table (id uuid, ag_owner text, ag_grantee text,
+    data_id text, locked_until int, ag_chain text, tx_hash text, height int, block_hash text)
+
+procedure migrate_external_grants($dbid text) public owner {
+    for $row in SELECT id, ag_owner, ag_grantee, data_id, locked_until, ag_chain, tx_hash, height, block_hash
+        FROM get_all_external_grants[$dbid, 'all_external_grants_as_owner']() {
+        INSERT INTO external_access_grants (id, ag_owner, ag_grantee, data_id, locked_until, ag_chain, tx_hash, height, block_hash)
+            VALUES ($row.id, $row.ag_owner, $row.ag_grantee, $row.data_id, $row.locked_until, $row.ag_chain,
+            $row.tx_hash, $row.height, $row.block_hash);
+    }
+}
+
+
 procedure all_internal_grants_as_owner() public view owner returns table (id uuid, ag_owner_human_id uuid, ag_grantee text,
     data_id uuid, locked_until int, write_grant_id uuid) {
     return SELECT id, ag_owner_human_id, ag_grantee, data_id, locked_until, write_grant_id FROM internal_access_grants;
 }
+
+foreign procedure get_all_internal_grants() returns table (id uuid, ag_owner_human_id uuid, ag_grantee text,
+    data_id uuid, locked_until int, write_grant_id uuid)
+
+procedure migrate_internal_grants($dbid text) public owner {
+    for $row in SELECT id, ag_owner_human_id, ag_grantee, data_id, locked_until, write_grant_id
+        FROM get_all_internal_grants[$dbid, 'all_internal_grants_as_owner']() {
+        INSERT INTO internal_access_grants (id, ag_owner_human_id, ag_grantee, data_id, locked_until, write_grant_id)
+            VALUES ($row.id, $row.ag_owner_human_id, $row.ag_grantee, $row.data_id, $row.locked_until, $row.write_grant_id);
+    }
+}
+
 
 procedure all_write_grants_as_owner() public view owner returns table (id uuid, wg_owner text, wg_grantee text,
     wg_owner_human_id uuid) {
     return SELECT id, wg_owner, wg_grantee, wg_owner_human_id FROM write_grants;
 }
 
+foreign procedure get_all_write_grants() returns table (id uuid, wg_owner text, wg_grantee text, wg_owner_human_id uuid)
+
+procedure migrate_write_grants($dbid text) public owner {
+    for $row in SELECT id, wg_owner, wg_grantee, wg_owner_human_id FROM get_all_write_grants[$dbid, 'all_write_grants_as_owner']() {
+        INSERT INTO write_grants (id, wg_owner, wg_grantee, wg_owner_human_id)
+            VALUES ($row.id, $row.wg_owner, $row.wg_grantee, $row.wg_owner_human_id);
+    }
+}
+
+
 procedure all_configs_as_owner() public view owner returns table (config_key text, value text) {
     return SELECT config_key, value FROM configs;
+}
+
+foreign procedure get_all_configs() returns table (config_key text, value text)
+
+procedure migrate_configs($dbid text) public owner {
+    for $row in SELECT config_key, value FROM get_all_configs[$dbid, 'all_configs_as_owner']() {
+        INSERT INTO configs (config_key, value)
+            VALUES ($row.config_key, $row.value);
+    }
+}
+
+// The sequence of inserting of tables is important
+procedure migrate_all_data($dbid text) public owner {
+    migrate_humans($dbid);
+    migrate_wallets($dbid);
+    migrate_credentials($dbid);
+    migrate_shared_credentials($dbid);
+    migrate_human_attributes($dbid);
+    migrate_shared_human_attrs($dbid);
+    migrate_inserters($dbid);
+    migrate_delegates($dbid);
+    migrate_external_grants($dbid);
+    migrate_write_grants($dbid); // WGs must be inserted before internal AGs
+    migrate_internal_grants($dbid);
+    migrate_configs($dbid);
 }

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -112,8 +112,11 @@ table internal_access_grants {
     ag_grantee text notnull,
     data_id uuid notnull,
     locked_until int notnull default(0),
-    write_grant_id uuid,
-    foreign_key (write_grant_id) references write_grants(id) on_delete set null
+    write_grant_id uuid, // This should be notnull, but we do set it to null in the FK.
+    foreign_key (write_grant_id) references write_grants(id) on_delete set null,
+    #iag_data_id index(data_id),
+    #iag_ag_grantee index(ag_grantee),
+    #iag_ag_owner_human_id index(ag_owner_human_id)
 }
 
 table configs {

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -95,6 +95,14 @@ table access_grants {
     #access_grants_data_id_owner index(data_id, ag_owner)
 }
 
+table write_grants {
+    id uuid primary,
+    wg_owner text notnull,
+    wg_grantee text notnull,
+    wg_owner_human_id uuid notnull,
+    #write_grants_human_id_grantee unique(wg_owner_human_id, wg_grantee)
+}
+
 table configs {
     config_key text primary,
     value text
@@ -309,6 +317,21 @@ procedure add_credential($id uuid, $credential_type text, $credential_level text
         $encryption_public_key,
         $issuer
     );
+}
+
+procedure add_credential_by_write_grant(
+    $id uuid,
+    $human_id uuid,
+    $credential_type text,
+    $credential_level text,
+    $credential_status text,
+    $content text,
+    $encryption_public_key text,
+    $issuer text) public {
+
+    $wg_id := get_write_grant_id($human_id);
+    INSERT INTO credentials (id, human_id, credential_type, credential_level, credential_status, content, encryption_public_key, issuer, inserter)
+    VALUES ($id, $human_id, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key, $issuer, $wg_id::TEXT);
 }
 
 // TODO: change to procedure
@@ -607,6 +630,33 @@ procedure define_ag_status_as_owner($ag_owner text, $ag_grantee text, $data_id u
         }
 
     return 'invalid_ag_owner_does_not_match_original_credential_owner';
+}
+
+
+// WRITE GRANTS ACTIONS
+
+procedure add_write_grant($wg_grantee text) public {
+    INSERT INTO write_grants (id, wg_owner, wg_grantee, wg_owner_human_id) VALUES (
+        uuid_generate_v5('31276fd4-105f-4ff7-9f64-644942c14b79'::uuid, format('%s-%s', @caller, $wg_grantee)),
+        @caller,
+        $wg_grantee,
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = @caller)
+        )
+    );
+}
+
+// Not sure we need this. But at least for testing it is valuable.
+procedure remove_write_grant($id uuid) public owner {
+    DELETE FROM write_grants WHERE id = $id;
+}
+
+procedure get_write_grant_id($human_id uuid) private view returns (id uuid) {
+    for $row in SELECT id FROM write_grants WHERE wg_owner_human_id = $human_id AND wg_grantee = @caller LIMIT 1 {
+        return $row.id;
+    }
+
+    error('there is no write grant found');
 }
 
 

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -354,7 +354,7 @@ procedure add_credential_by_write_grant(
 // TODO: change to procedure
 @kgw(authn='true')
 action get_credentials() public view {
-	SELECT DISTINCT c.id, c.human_id, c.inserter, c.credential_type, c.credential_level, c.credential_status, c.issuer, sc.original_id AS original_id
+    SELECT DISTINCT c.id, c.human_id, c.inserter, c.credential_type, c.credential_level, c.credential_status, c.issuer, sc.original_id AS original_id
     FROM credentials AS c
     LEFT JOIN shared_credentials AS sc ON c.id = sc.duplicate_id
     INNER JOIN wallets ON c.human_id = wallets.human_id
@@ -623,7 +623,7 @@ procedure add_attribute($id uuid, $attribute_key text, $value text) public {
 // TODO: change to procedure
 @kgw(authn='true')
 action get_attributes() public view {
-	SELECT DISTINCT ha.id, ha.human_id, ha.attribute_key, ha.value, sha.original_id AS original_id
+    SELECT DISTINCT ha.id, ha.human_id, ha.attribute_key, ha.value, sha.original_id AS original_id
     FROM human_attributes AS ha
     LEFT JOIN shared_human_attributes AS sha ON ha.id = sha.duplicate_id
     INNER JOIN wallets ON ha.human_id = wallets.human_id

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -673,13 +673,20 @@ procedure list_external_ag_statuses($data_id text) public view returns table (ag
 
 @kgw(authn='true')
 procedure has_locked_grants($id uuid) public view returns (has bool) {
-    for $row in SELECT 1 FROM external_access_grants
+    for $ext_row in SELECT 1 FROM external_access_grants
             WHERE data_id = $id::TEXT
-            AND ag_owner = @caller COLLATE NOCASE
+            AND ag_owner = @caller COLLATE NOCASE // not shure if this condition necessary as we now have owner validation reflected in status
             AND status = 'valid'
             AND locked_until >= @block_timestamp LIMIT 1 {
         return true;
     }
+
+    for $int_row in SELECT 1 FROM internal_access_grants
+            WHERE data_id = $id
+            AND locked_until >= @block_timestamp LIMIT 1 {
+        return true;
+    }
+
     return false;
 }
 

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -521,33 +521,28 @@ procedure get_credential_shared ($id uuid) public view returns table (id uuid, h
         error('the credential does not exist');
     }
 
-    $ag_granted bool := false;
-    $ag_grant_valid bool := false;
-    $wg_granted bool := false;
+    $ext_ag_granted bool := false;
+    $ext_ag_grant_valid bool := false;
+    $int_ag_granted bool := false;
 
-    for $row in SELECT status FROM external_access_grants WHERE data_id = $id::TEXT AND ag_grantee = @caller COLLATE NOCASE {
-        $granted := true;
-        if $row.status == 'valid' {
-            $ag_grant_valid := true;
+    for $ext_ag_row in SELECT status FROM external_access_grants WHERE data_id = $id::TEXT AND ag_grantee = @caller COLLATE NOCASE {
+        $ext_ag_granted := true;
+        if $ext_ag_row.status == 'valid' {
+            $ext_ag_grant_valid := true;
             break;
         }
     }
 
-    // TODO look in internal_access_grants, not write_grants.
-    for $row2 in SELECT 1 FROM write_grants INNER JOIN credentials ON write_grants.wg_owner_human_id = credentials.human_id
-        WHERE credentials.id = $id
-            AND write_grants.wg_grantee = @caller COLLATE NOCASE
-            AND credentials.inserter = @caller LIMIT 1 {
-
-        $wg_granted := true;
+    for $int_ag_row in SELECT 1 FROM internal_access_grants WHERE data_id = $id AND ag_grantee = @caller COLLATE NOCASE {
+        $int_ag_granted := true;
     }
 
-    if !$ag_granted and !$wg_granted {
+    if !$ext_ag_granted and !$int_ag_granted {
         error('the credential is not shared with the caller');
     }
 
-    if $ag_granted and !$wg_granted and !$ag_grant_valid {
-        error('the credential has no valid access grant; for more details, call list_ag_statuses');
+    if $ext_ag_granted and !$int_ag_granted and !$ext_ag_grant_valid {
+        error('the credential has no valid access grant; for more details, call list_external_ag_statuses');
     }
 
     return SELECT id, human_id, credential_type, credential_level, credential_status, content, encryption_public_key,
@@ -668,7 +663,7 @@ procedure share_attribute($id uuid, $original_attribute_id uuid, $attribute_key 
 // ACCEESS GRANTS ACTIONS
 
 @kgw(authn='true')
-procedure list_ag_statuses($data_id text) public view returns table (ag_owner text, ag_grantee text, locked_until int, status text) {
+procedure list_external_ag_statuses($data_id text) public view returns table (ag_owner text, ag_grantee text, locked_until int, status text) {
     return
         SELECT ag_owner, ag_grantee, locked_until, status
         FROM external_access_grants

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -330,8 +330,13 @@ procedure add_credential_by_write_grant(
     $issuer text) public {
 
     $wg_id := get_write_grant_id($human_id);
+
+    if $wg_id == '' {
+        error('there is no write grant found');
+    }
+
     INSERT INTO credentials (id, human_id, credential_type, credential_level, credential_status, content, encryption_public_key, issuer, inserter)
-    VALUES ($id, $human_id, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key, $issuer, $wg_id::TEXT);
+    VALUES ($id, $human_id, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key, $issuer, $wg_id);
 }
 
 // TODO: change to procedure
@@ -449,19 +454,21 @@ procedure share_credential_by_write_grant(
     $encryption_public_key text,
     $issuer text) public {
 
-    // will fail if no WG
     $wg_id := get_write_grant_id($human_id);
+    if $wg_id == '' {
+        error('there is no write grant found');
+    }
 
     if !credential_belongs_to_human($original_credential_id, $human_id) {
         error('the original credential does not belong to the human');
     }
 
-    if $wg_id::TEXT != get_credential_inserter($original_credential_id) {
+    if $wg_id != get_credential_inserter($original_credential_id) {
         error('you can share only original credentials you created');
     }
 
     INSERT INTO credentials (id, human_id, credential_type, credential_level, credential_status, content, encryption_public_key, issuer, inserter)
-        VALUES ($id, $human_id, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key, $issuer, $wg_id::TEXT);
+        VALUES ($id, $human_id, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key, $issuer, $wg_id);
     INSERT INTO shared_credentials (original_id, duplicate_id) VALUES ($original_credential_id, $id);
 }
 
@@ -491,22 +498,31 @@ procedure get_credential_shared ($id uuid) public view returns table (id uuid, h
         error('the credential does not exist');
     }
 
-    $granted bool := false;
-    $grant_valid bool := false;
+    $ag_granted bool := false;
+    $ag_grant_valid bool := false;
+    $wg_granted bool := false;
 
     for $row in SELECT status FROM access_grants WHERE data_id = $id::TEXT AND ag_grantee = @caller COLLATE NOCASE {
-        $granted := true;
+        $ag_granted := true;
         if $row.status == 'valid' {
-            $grant_valid := true;
+            $ag_grant_valid := true;
             break;
         }
     }
 
-    if !$granted {
+    for $row2 in SELECT 1 FROM write_grants INNER JOIN credentials ON write_grants.wg_owner_human_id = credentials.human_id
+        WHERE credentials.id = $id
+            AND write_grants.wg_grantee = @caller COLLATE NOCASE
+            AND credentials.inserter = @caller LIMIT 1 {
+
+        $wg_granted := true;
+    }
+
+    if !$ag_granted and !$wg_granted {
         error('the credential is not shared with the caller');
     }
 
-    if !$grant_valid {
+    if $ag_granted and !$wg_granted and !$ag_grant_valid {
         error('the credential has no valid access grant; for more details, call list_ag_statuses');
     }
 
@@ -694,12 +710,12 @@ procedure remove_write_grant($id uuid) public owner {
     DELETE FROM write_grants WHERE id = $id;
 }
 
-procedure get_write_grant_id($human_id uuid) private view returns (id uuid) {
-    for $row in SELECT id FROM write_grants WHERE wg_owner_human_id = $human_id AND wg_grantee = @caller LIMIT 1 {
-        return $row.id;
+procedure get_write_grant_id($human_id uuid) private view returns (id text) {
+    for $row in SELECT id FROM write_grants WHERE wg_owner_human_id = $human_id AND wg_grantee = @caller COLLATE NOCASE LIMIT 1 {
+        return $row.id::TEXT;
     }
 
-    error('there is no write grant found');
+    return '';
 }
 
 

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -733,8 +733,15 @@ procedure add_write_grant($wg_grantee text) public {
     );
 }
 
+procedure remove_write_grant($wg_grantee text) public {
+    DELETE FROM write_grants
+        WHERE wg_grantee = $wg_grantee COLLATE NOCASE
+        AND wg_owner_human_id = (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = @caller));
+}
+
 // Not sure we need this. But at least for testing it is valuable.
-procedure remove_write_grant($id uuid) public owner {
+procedure remove_write_grant_as_owner($id uuid) public owner {
     DELETE FROM write_grants WHERE id = $id;
 }
 

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -530,7 +530,7 @@ procedure get_credential_shared ($id uuid) public view returns table (id uuid, h
         issuer, inserter FROM credentials WHERE id = $id;
 }
 
-procedure credential_belongs_to_human($id uuid, $human_id uuid) private returns (belongs bool) {
+procedure credential_belongs_to_human($id uuid, $human_id uuid) private view returns (belongs bool) {
     for $row in SELECT 1 from credentials WHERE id = $id AND human_id = $human_id LIMIT 1 {
         return true;
     }
@@ -538,7 +538,7 @@ procedure credential_belongs_to_human($id uuid, $human_id uuid) private returns 
     return false;
 }
 
-procedure credential_belongs_to_caller($id uuid) private returns (belongs bool) {
+procedure credential_belongs_to_caller($id uuid) private view returns (belongs bool) {
     for $row in SELECT 1 from credentials
         WHERE id = $id
         AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -108,10 +108,10 @@ table write_grants {
 // internal access grants can be granted if such permission is in write_grants
 table internal_access_grants {
     id uuid primary,
-    ag_owner text notnull,
+    ag_owner_human_id uuid notnull,
     ag_grantee text notnull,
-    data_id text notnull,
-    locked_until int notnull,
+    data_id uuid notnull,
+    locked_until int notnull default(0),
     write_grant_id uuid,
     foreign_key (write_grant_id) references write_grants(id) on_delete set null
 }
@@ -342,14 +342,10 @@ procedure add_credential_by_write_grant(
     $encryption_public_key text,
     $issuer text) public {
 
-    $wg_id := get_write_grant_id($human_id);
-
-    if $wg_id == '' {
-        error('there is no write grant found');
-    }
+    $wg_id := get_write_grant_id($human_id); // throw an error if no write_grant
 
     INSERT INTO credentials (id, human_id, credential_type, credential_level, credential_status, content, encryption_public_key, issuer, inserter)
-    VALUES ($id, $human_id, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key, $issuer, $wg_id);
+    VALUES ($id, $human_id, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key, $issuer, $wg_id::TEXT);
 }
 
 // TODO: change to procedure
@@ -460,32 +456,43 @@ procedure share_credential_by_write_grant(
     $id uuid,
     $human_id uuid,
     $original_credential_id uuid,
-    // TODO add grantee
-    // TODO add timelock
     $credential_type text,
     $credential_level text,
     $credential_status text,
     $content text,
     $encryption_public_key text,
+    $grantee text,
+    $locked_until int,
     $issuer text) public {
 
-    $wg_id := get_write_grant_id($human_id);
-    if $wg_id == '' {
-        error('there is no write grant found');
+    if $locked_until < 0 {
+        error('locked_until must be positive integer timestamp or zero');
     }
+
+    $wg_id := get_write_grant_id($human_id); // throw an error if no write_grant
 
     if !credential_belongs_to_human($original_credential_id, $human_id) {
         error('the original credential does not belong to the human');
     }
 
-    if $wg_id != get_credential_inserter($original_credential_id) {
+    if $wg_id::TEXT != get_credential_inserter($original_credential_id) {
         error('you can share only original credentials you created');
     }
 
     INSERT INTO credentials (id, human_id, credential_type, credential_level, credential_status, content, encryption_public_key, issuer, inserter)
-        VALUES ($id, $human_id, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key, $issuer, $wg_id);
+        VALUES ($id, $human_id, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key, $issuer, $wg_id::TEXT);
+
     INSERT INTO shared_credentials (original_id, duplicate_id) VALUES ($original_credential_id, $id);
-    INSERT INTO internal_access_grants(); //TODO write the actual code
+
+    INSERT INTO internal_access_grants (id, ag_owner_human_id, ag_grantee, data_id, locked_until, write_grant_id)
+        VALUES (
+            uuid_generate_v5('31276fd4-105f-4ff7-9f64-644942c14b79'::uuid, format('%s-%s-%s', $grantee, $id, $locked_until)),
+            $human_id,
+            $grantee,
+            $id,
+            $locked_until,
+            $wg_id
+        );
 }
 
 @kgw(authn='true')
@@ -727,12 +734,12 @@ procedure remove_write_grant($id uuid) public owner {
     DELETE FROM write_grants WHERE id = $id;
 }
 
-procedure get_write_grant_id($human_id uuid) private view returns (id text) {
+procedure get_write_grant_id($human_id uuid) private view returns (id uuid) {
     for $row in SELECT id FROM write_grants WHERE wg_owner_human_id = $human_id AND wg_grantee = @caller COLLATE NOCASE LIMIT 1 {
-        return $row.id::TEXT;
+        return $row.id;
     }
 
-    return '';
+    error('there is no write grant found');
 }
 
 
@@ -802,10 +809,10 @@ procedure insert_external_ags_as_owner($id uuid, $ag_owner text, $ag_grantee tex
         $tx_hash, $block_hash, $height, $status);
 }
 
-procedure insert_internal_ags_as_owner($id uuid, $ag_owner text, $ag_grantee text, $data_id text,
+procedure insert_internal_ags_as_owner($id uuid, $ag_owner_human_id uuid, $ag_grantee text, $data_id uuid,
     $locked_until int, $write_grant_id uuid) owner public {
-    INSERT INTO internal_access_grants (id, ag_owner, ag_grantee, data_id, locked_until, write_grant_id)
-    VALUES ($id, $ag_owner, $ag_grantee, $data_id, $locked_until, $write_grant_id);
+    INSERT INTO internal_access_grants (id, ag_owner_human_id, ag_grantee, data_id, locked_until, write_grant_id)
+    VALUES ($id, $ag_owner_human_id, $ag_grantee, $data_id, $locked_until, $write_grant_id);
 }
 
 procedure insert_write_grants_as_owner($id uuid, $wg_owner text, $wg_grantee text, $wg_owner_human_id uuid) owner public {
@@ -857,9 +864,9 @@ procedure all_external_grants_as_owner() public view owner returns table (id uui
     return SELECT id, ag_owner, ag_grantee, data_id, locked_until, ag_chain, tx_hash, height, block_hash FROM external_access_grants;
 }
 
-procedure all_internal_grants_as_owner() public view owner returns table (id uuid, ag_owner text, ag_grantee text,
-    data_id text, locked_until int, write_grant_id uuid) {
-    return SELECT id, ag_owner, ag_grantee, data_id, locked_until, write_grant_id FROM internal_access_grants;
+procedure all_internal_grants_as_owner() public view owner returns table (id uuid, ag_owner_human_id uuid, ag_grantee text,
+    data_id uuid, locked_until int, write_grant_id uuid) {
+    return SELECT id, ag_owner_human_id, ag_grantee, data_id, locked_until, write_grant_id FROM internal_access_grants;
 }
 
 procedure all_write_grants_as_owner() public view owner returns table (id uuid, wg_owner text, wg_grantee text,

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -398,25 +398,6 @@ procedure share_credential(
     INSERT INTO shared_credentials (original_id, duplicate_id) VALUES ($original_credential_id, $id);
 }
 
-procedure credential_belongs_to_human($id uuid, $human_id uuid) private returns (belongs bool) {
-    for $row in SELECT 1 from credentials WHERE id = $id AND human_id = $human_id LIMIT 1 {
-        return true;
-    }
-
-    return false;
-}
-
-procedure credential_belongs_to_caller($id uuid) private returns (belongs bool) {
-    for $row in SELECT 1 from credentials
-        WHERE id = $id
-        AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-            OR (wallet_type = 'NEAR' AND public_key = @caller)) {
-        return true;
-    }
-
-    return false;
-}
-
 action share_credential_through_dag (
         $id,
         $human_id,
@@ -475,9 +456,9 @@ procedure share_credential_by_write_grant(
         error('the original credential does not belong to the human');
     }
 
-    // if $wg_id != get_credential_inserter($original_credential_id) {
-    //     error('you can share only original credentials you created');
-    // }
+    if $wg_id::TEXT != get_credential_inserter($original_credential_id) {
+        error('you can share only original credentials you created');
+    }
 
     INSERT INTO credentials (id, human_id, credential_type, credential_level, credential_status, content, encryption_public_key, issuer, inserter)
         VALUES ($id, $human_id, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key, $issuer, $wg_id::TEXT);
@@ -533,11 +514,38 @@ procedure get_credential_shared ($id uuid) public view returns table (id uuid, h
         issuer, inserter FROM credentials WHERE id = $id;
 }
 
+procedure credential_belongs_to_human($id uuid, $human_id uuid) private returns (belongs bool) {
+    for $row in SELECT 1 from credentials WHERE id = $id AND human_id = $human_id LIMIT 1 {
+        return true;
+    }
+
+    return false;
+}
+
+procedure credential_belongs_to_caller($id uuid) private returns (belongs bool) {
+    for $row in SELECT 1 from credentials
+        WHERE id = $id
+        AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = @caller)) {
+        return true;
+    }
+
+    return false;
+}
+
 procedure credential_exist($id uuid) private view returns (credential_exist bool) {
     for $row in SELECT 1 FROM credentials WHERE id = $id {
         return true;
     }
     return false;
+}
+
+procedure get_credential_inserter($id uuid) private view returns (inserter text) {
+    for $row in SELECT inserter FROM credentials WHERE id = $id LIMIT 1 {
+        return $row.inserter;
+    }
+
+    error('credential not found');
 }
 
 

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -351,7 +351,7 @@ procedure add_credential_by_write_grant(
 // TODO: change to procedure
 @kgw(authn='true')
 action get_credentials() public view {
-	SELECT DISTINCT c.id, c.human_id, c.inserter, c.credential_type, c.credential_level, c.credential_status, sc.original_id AS original_id
+	SELECT DISTINCT c.id, c.human_id, c.inserter, c.credential_type, c.credential_level, c.credential_status, c.issuer, sc.original_id AS original_id
     FROM credentials AS c
     LEFT JOIN shared_credentials AS sc ON c.id = sc.duplicate_id
     INNER JOIN wallets ON c.human_id = wallets.human_id
@@ -485,6 +485,11 @@ procedure share_credential_by_write_grant(
         error('you can share only original credentials you created');
     }
 
+    $generated_uuid := uuid_generate_v5('31276fd4-105f-4ff7-9f64-644942c14b79'::uuid, format('%s-%s-%s', $grantee, $original_credential_id, $locked_until));
+    for $row in SELECT 1 FROM internal_access_grants WHERE id = $generated_uuid LIMIT 1 {
+        error('the grant with the same grantee, original_credential_id and locked_until exists');
+    }
+
     INSERT INTO credentials (id, human_id, credential_type, credential_level, credential_status, content, encryption_public_key, issuer, inserter)
         VALUES ($id, $human_id, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key, $issuer, $wg_id::TEXT);
 
@@ -492,7 +497,7 @@ procedure share_credential_by_write_grant(
 
     INSERT INTO internal_access_grants (id, ag_owner_human_id, ag_grantee, data_id, locked_until, write_grant_id)
         VALUES (
-            uuid_generate_v5('31276fd4-105f-4ff7-9f64-644942c14b79'::uuid, format('%s-%s-%s', $grantee, $id, $locked_until)),
+            $generated_uuid,
             $human_id,
             $grantee,
             $id,
@@ -737,6 +742,24 @@ procedure get_write_grant_id($human_id uuid) private view returns (id uuid) {
 // INTERNAL ACCESS GRANTS ACTIONS
 
 procedure revoke_internal_access_grant ($id uuid) public {
+    $iag_exist := false;
+    for $row in SELECT 1 FROM internal_access_grants WHERE id = $id
+        AND ag_owner_human_id = (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = @caller)) {
+        $iag_exist := true;
+    }
+
+    if !$iag_exist {
+        error('the internal access grant not found');
+    }
+
+    for $row2 in SELECT 1 FROM internal_access_grants WHERE id = $id
+        AND locked_until >= @block_timestamp
+        AND ag_owner_human_id = (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = @caller)) {
+        error('the grant is locked');
+    }
+
     DELETE FROM internal_access_grants
     WHERE id = $id
     AND ag_owner_human_id = (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -1,4 +1,4 @@
-database idos_mig;
+database idos;
 
 // EXTENSION INITIALIZATION
 

--- a/schema.development.kf
+++ b/schema.development.kf
@@ -1061,17 +1061,17 @@ procedure migrate_configs($dbid text) public owner {
 }
 
 // The sequence of inserting of tables is important
-procedure migrate_all_data($dbid text) public owner {
-    migrate_humans($dbid);
-    migrate_wallets($dbid);
-    migrate_credentials($dbid);
-    migrate_shared_credentials($dbid);
-    migrate_human_attributes($dbid);
-    migrate_shared_human_attrs($dbid);
-    migrate_inserters($dbid);
-    migrate_delegates($dbid);
-    migrate_external_grants($dbid);
-    migrate_write_grants($dbid); // WGs must be inserted before internal AGs
-    migrate_internal_grants($dbid);
-    migrate_configs($dbid);
+procedure migrate_all_data($old_dbid text) public owner {
+    migrate_humans($old_dbid);
+    migrate_wallets($old_dbid);
+    migrate_credentials($old_dbid);
+    migrate_shared_credentials($old_dbid);
+    migrate_human_attributes($old_dbid);
+    migrate_shared_human_attrs($old_dbid);
+    migrate_inserters($old_dbid);
+    migrate_delegates($old_dbid);
+    migrate_external_grants($old_dbid);
+    migrate_write_grants($old_dbid); // WGs must be inserted before internal AGs
+    migrate_internal_grants($old_dbid);
+    migrate_configs($old_dbid);
 }

--- a/schema.development_temp.kf
+++ b/schema.development_temp.kf
@@ -112,8 +112,11 @@ table internal_access_grants {
     ag_grantee text notnull,
     data_id uuid notnull,
     locked_until int notnull default(0),
-    write_grant_id uuid,
-    foreign_key (write_grant_id) references write_grants(id) on_delete set null
+    write_grant_id uuid, // This should be notnull, but we do set it to null in the FK.
+    foreign_key (write_grant_id) references write_grants(id) on_delete set null,
+    #iag_data_id index(data_id),
+    #iag_ag_grantee index(ag_grantee),
+    #iag_ag_owner_human_id index(ag_owner_human_id)
 }
 
 table configs {
@@ -1007,7 +1010,7 @@ foreign procedure get_all_external_grants() returns table (id uuid, ag_owner tex
 
 procedure migrate_external_grants($dbid text) public owner {
     for $row in SELECT id, ag_owner, ag_grantee, data_id, locked_until, ag_chain, tx_hash, height, block_hash
-        FROM get_all_external_grants[$dbid, 'all_grants_as_owner']() { // TODO Change this to all_external_grants_as_owner after migration
+        FROM get_all_external_grants[$dbid, 'all_external_grants_as_owner']() {
         INSERT INTO external_access_grants (id, ag_owner, ag_grantee, data_id, locked_until, ag_chain, tx_hash, height, block_hash)
             VALUES ($row.id, $row.ag_owner, $row.ag_grantee, $row.data_id, $row.locked_until, $row.ag_chain,
             $row.tx_hash, $row.height, $row.block_hash);
@@ -1071,7 +1074,7 @@ procedure migrate_all_data($old_dbid text) public owner {
     migrate_inserters($old_dbid);
     migrate_delegates($old_dbid);
     migrate_external_grants($old_dbid);
-    // migrate_write_grants($old_dbid); // WGs must be inserted before internal AGs
-    // migrate_internal_grants($old_dbid);
+    migrate_write_grants($old_dbid); // WGs must be inserted before internal AGs
+    migrate_internal_grants($old_dbid);
     migrate_configs($old_dbid);
 }

--- a/schema.development_temp.kf
+++ b/schema.development_temp.kf
@@ -1,0 +1,1077 @@
+database idos_temp;
+
+// EXTENSION INITIALIZATION
+
+use idos as idos;
+
+
+// TABLES
+
+table humans {
+    id uuid primary,
+    current_public_key text notnull,
+    inserter text notnull
+}
+
+table wallets {
+    id uuid primary,
+    human_id uuid notnull,
+    address text notnull,
+    public_key text,
+    wallet_type text notnull,
+    message text,
+    signature text,
+    inserter text,
+    #wallets_human_id index(human_id),
+    #wallets_evm_scan index(wallet_type, address),
+    #wallets_near_scan index(wallet_type, public_key),
+    foreign_key (human_id) references humans(id) on_delete cascade
+}
+
+table credentials {
+    id uuid primary,
+    human_id uuid notnull,
+    credential_type text notnull,
+    credential_level text,
+    credential_status text, // idOS credential's status, not VC status (VC statuses are managed inside VC content and revocations mechanism)
+    content text notnull,
+    encryption_public_key text notnull, // public key of encryptor
+    issuer text notnull,
+    inserter text,
+    #credentials_human_id index(human_id),
+    foreign_key (human_id) references humans(id) on_delete cascade
+}
+
+table shared_credentials {
+    original_id uuid notnull,
+    duplicate_id uuid notnull,
+    #primary_key primary(original_id, duplicate_id),
+    #shared_credentials_duplicate_id index(duplicate_id),
+    foreign_key (original_id) references credentials(id) on_delete cascade,
+    foreign_key (duplicate_id) references credentials(id) on_delete cascade
+}
+
+table human_attributes {
+    id uuid primary,
+    human_id uuid notnull,
+    attribute_key text notnull,
+    value text notnull,
+    inserter text,
+    #human_attributes_human_id index(human_id),
+    foreign_key (human_id) references humans(id) on_delete cascade
+}
+
+table shared_human_attributes {
+    original_id uuid notnull,
+    duplicate_id uuid notnull,
+    #primary_key primary(original_id, duplicate_id),
+    foreign_key (original_id) references human_attributes(id) on_delete cascade,
+    foreign_key (duplicate_id) references human_attributes(id) on_delete cascade
+}
+
+table inserters {
+    id uuid primary,
+    name text unique notnull
+}
+
+table delegates {
+    address text primary,
+    inserter_id uuid notnull,
+    foreign_key (inserter_id) references inserters(id) on_delete cascade
+}
+
+table external_access_grants {
+    id uuid primary,
+    ag_owner text notnull,
+    ag_grantee text notnull,
+    data_id text notnull,
+    locked_until int notnull,
+    ag_chain text notnull,
+    tx_hash text,
+    block_hash text,
+    height int,
+    // data_id in contract can be any data, but idOS expects uuid of a credential, so we need a status field to mark validity of the access grant
+    status text, // valid, invalid_by_reason, ...
+    #external_ag_data_id_grantee index(data_id, ag_grantee),
+    #external_ag_data_id_owner index(data_id, ag_owner)
+}
+
+// A human/user gives a grant to write data (create a credential, share the credential) on his behalf to some issuer
+table write_grants {
+    id uuid primary,
+    wg_owner text notnull, // human wallet/pk
+    wg_grantee text notnull, // issuer wallet/pk
+    wg_owner_human_id uuid notnull, // human's id, to be sure we will find the human if the owner's wallet will be deleted
+    #write_grants_human_id_grantee unique(wg_owner_human_id, wg_grantee)
+}
+
+// internal access grants can be granted if such permission is in write_grants
+table internal_access_grants {
+    id uuid primary,
+    ag_owner_human_id uuid notnull,
+    ag_grantee text notnull,
+    data_id uuid notnull,
+    locked_until int notnull default(0),
+    write_grant_id uuid,
+    foreign_key (write_grant_id) references write_grants(id) on_delete set null
+}
+
+table configs {
+    config_key text primary,
+    value text
+}
+
+
+// CONFIG ACTIONS
+
+procedure upsert_config_as_owner($config_key text, $value text) public owner {
+    INSERT INTO configs (config_key, value) VALUES ($config_key, $value)
+        ON CONFLICT(config_key) DO UPDATE
+            SET value = $value;
+}
+
+procedure delete_config_as_owner($config_key text) public owner {
+    DELETE FROM configs WHERE config_key = $config_key;
+}
+
+procedure get_config_as_owner($config_key text) public view owner returns (value text) {
+    for $row in SELECT config_key, value FROM configs WHERE config_key = $config_key {
+        return $row.value;
+    }
+}
+
+
+// INSERTER AND DELEGATE ACTIONS
+
+procedure add_inserter_as_owner($id uuid, $name text) owner public {
+    INSERT INTO inserters (id, name) VALUES ($id, $name);
+}
+
+procedure delete_inserter_as_owner($id uuid) owner public {
+    DELETE FROM inserters WHERE id = $id;
+}
+
+procedure add_delegate_as_owner($address text, $inserter_id uuid) owner public {
+  INSERT INTO delegates (address, inserter_id) VALUES ($address, $inserter_id);
+}
+
+procedure delete_delegate_as_owner($address text) owner public {
+  DELETE FROM delegates WHERE address=$address;
+}
+
+procedure get_inserter() private view returns (name text) {
+    for $row in SELECT inserters.name FROM inserters INNER JOIN delegates ON inserters.id = delegates.inserter_id WHERE delegates.address = @caller {
+        return $row.name;
+    }
+    error('Unauthorized inserter');
+}
+
+procedure get_inserter_or_null() private view returns (name text) {
+    for $row in SELECT inserters.name FROM inserters INNER JOIN delegates ON inserters.id = delegates.inserter_id WHERE delegates.address = @caller {
+        return $row.name;
+    }
+    return null;
+}
+
+// HUMAN ACTIONS
+
+procedure add_human_as_inserter($id uuid, $current_public_key text) public {
+    INSERT INTO humans (id, current_public_key, inserter) VALUES ($id, $current_public_key, get_inserter());
+}
+
+procedure update_human_pub_key_as_inserter($id uuid, $current_public_key text) public {
+    get_inserter();
+    UPDATE humans SET current_public_key=$current_public_key
+        WHERE id = $id;
+}
+
+// For development, for not to drop a DB if we need to clear it. Should not be in prod envs.
+procedure delete_human_as_owner($id uuid) public owner {
+    DELETE FROM humans WHERE id=$id;
+}
+
+// TODO: delete this after idos-sdk starts using get_human action
+// DEPRECATED
+@kgw(authn='true')
+action get_wallet_human_id() public view {
+    SELECT DISTINCT human_id FROM wallets
+    WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = @caller);
+}
+
+// TODO: change to procedure
+@kgw(authn='true')
+action get_human() public view {
+    SELECT id, current_public_key FROM humans
+    WHERE id = (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = @caller));
+}
+
+@kgw(authn='true')
+procedure get_human_as_inserter($id uuid) public view returns (id uuid, current_public_key text, inserter text) {
+    get_inserter();
+    for $row in SELECT * FROM humans WHERE id = $id {
+        return $row.id, $row.current_public_key, $row.inserter;
+    }
+}
+
+
+// WALLET ACTIONS
+
+// TODO: change to procedure
+action upsert_wallet_as_inserter($id, $human_id, $address, $public_key, $wallet_type, $message, $signature) public {
+    SELECT CASE WHEN $wallet_type = 'NEAR' AND $public_key::TEXT IS NULL THEN ERROR('NEAR wallets require a public_key to be given.') END;
+
+    $valid_public_key = idos.is_valid_public_key($public_key, $wallet_type);
+    SELECT CASE WHEN $wallet_type = 'NEAR' AND $valid_public_key != 1 THEN ERROR('Invalid or unsupported public key.') END;
+
+    INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature, inserter)
+    VALUES ($id, $human_id, $address, $public_key, $wallet_type, $message, $signature, get_inserter())
+    ON CONFLICT(id) DO UPDATE
+    SET human_id=$human_id, address=$address, public_key=$public_key, wallet_type=$wallet_type, message=$message, signature=$signature, inserter=get_inserter();
+}
+
+// Temporary, to remove wrong data from initial test period. Owner only.
+procedure delete_wallet_as_owner($id uuid) public owner {
+    DELETE FROM wallets WHERE id=$id;
+}
+
+// Do we need to ask user/sdk to provide id? It is possible now to generate the `id` in the procedure in consensus way
+action add_wallet($id, $address, $public_key, $message, $signature) public {
+    $wallet_type = idos.determine_wallet_type($address);
+
+    SELECT CASE WHEN $wallet_type = 'NEAR' AND $public_key::TEXT IS NULL THEN ERROR('NEAR wallets require a public_key to be given.') END;
+
+    $valid_public_key = idos.is_valid_public_key($public_key, $wallet_type);
+    SELECT CASE WHEN $wallet_type = 'NEAR' AND $valid_public_key != 1 THEN ERROR('Invalid or unsupported public key.') END;
+
+    INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
+    VALUES (
+        $id,
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = @caller)
+        ),
+        $address,
+        CASE
+            WHEN $public_key = '' THEN NULL
+            ELSE $public_key
+        END,
+        $wallet_type,
+        $message,
+        $signature
+    );
+}
+
+// TODO: change to procedure
+@kgw(authn='true')
+action get_wallets() public view {
+    SELECT DISTINCT w1.*
+    FROM wallets AS w1
+    INNER JOIN wallets AS w2 ON w1.human_id = w2.human_id
+    WHERE (
+        w2.wallet_type = 'EVM' AND w2.address = @caller COLLATE NOCASE
+    ) OR (
+        w2.wallet_type = 'NEAR' AND w2.public_key = @caller
+    );
+}
+
+procedure remove_wallet($id uuid) public {
+    for $row in SELECT id FROM wallets
+        WHERE id = $id
+        AND ((wallet_type = 'EVM' AND address=@caller COLLATE NOCASE) OR (wallet_type = 'NEAR' AND public_key = @caller))
+        AND EXISTS (
+            SELECT count(id) FROM wallets
+                WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE) OR (wallet_type = 'NEAR' AND public_key = @caller)
+                GROUP BY human_id HAVING count(id) = 1
+        ) {
+        error('You can not delete a wallet you are connected with. To delete this wallet you have to connect other wallet.');
+    }
+
+    DELETE FROM wallets
+    WHERE id=$id AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = @caller)
+    );
+}
+
+
+// CREDENTIAL ACTIONS
+
+procedure upsert_credential_as_inserter(
+        $id uuid,
+        $human_id uuid,
+        $credential_type text,
+        $credential_level text,
+        $credential_status text,
+        $content text,
+        $encryption_public_key text,
+        $issuer text) public returns (bool) {
+    $inserter text := get_inserter();
+    INSERT INTO credentials (id, human_id, credential_type, credential_level, credential_status, content, encryption_public_key, issuer, inserter)
+    VALUES ($id, $human_id, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key, $issuer, $inserter)
+    ON CONFLICT(id) DO UPDATE
+    SET credential_status=$credential_status, content=$content, encryption_public_key=$encryption_public_key, issuer=$issuer, inserter=$inserter;
+
+    // Do we still need this return?
+    return true; // dummy return value is needed when the procedure is called from an action like `SELECT procedure_call()`;
+}
+
+procedure add_credential($id uuid, $credential_type text, $credential_level text, $credential_status text, $content text,
+    $encryption_public_key text, $issuer text) public {
+    INSERT INTO credentials (id, human_id, credential_type, credential_level, credential_status, content, encryption_public_key, issuer)
+    VALUES (
+        $id,
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = @caller)
+        ),
+        $credential_type,
+        $credential_level,
+        $credential_status,
+        $content,
+        $encryption_public_key,
+        $issuer
+    );
+}
+
+procedure add_credential_by_write_grant(
+    $id uuid,
+    $human_id uuid,
+    $credential_type text,
+    $credential_level text,
+    $credential_status text,
+    $content text,
+    $encryption_public_key text,
+    $issuer text) public {
+
+    $wg_id := get_write_grant_id($human_id); // throw an error if no write_grant
+
+    INSERT INTO credentials (id, human_id, credential_type, credential_level, credential_status, content, encryption_public_key, issuer, inserter)
+    VALUES ($id, $human_id, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key, $issuer, $wg_id::TEXT);
+}
+
+// TODO: change to procedure
+@kgw(authn='true')
+action get_credentials() public view {
+	SELECT DISTINCT c.id, c.human_id, c.inserter, c.credential_type, c.credential_level, c.credential_status, c.issuer, sc.original_id AS original_id
+    FROM credentials AS c
+    LEFT JOIN shared_credentials AS sc ON c.id = sc.duplicate_id
+    INNER JOIN wallets ON c.human_id = wallets.human_id
+    WHERE (
+        wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE
+    ) OR (
+        wallets.wallet_type = 'NEAR' AND wallets.public_key = @caller
+    );
+}
+
+// TODO: change to procedure
+action edit_credential($id, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key, $issuer) public {
+    SELECT CASE
+        WHEN EXISTS (
+            SELECT 1 from credentials AS c
+                INNER JOIN shared_credentials AS sc on c.id = sc.duplicate_id
+                WHERE c.id = $id
+                AND c.human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+                    OR (wallet_type = 'NEAR' AND public_key = @caller))
+        ) THEN ERROR('Can not edit shared credential') END;
+
+    UPDATE credentials
+    SET credential_type=$credential_type, credential_level=$credential_level, credential_status=$credential_status,
+        content=$content, encryption_public_key=$encryption_public_key, issuer=$issuer
+    WHERE id=$id
+    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = @caller)
+    );
+}
+
+procedure remove_credential($id uuid) public {
+    if !credential_belongs_to_caller($id) {
+        error('the credential does not belong to the caller');
+    }
+
+    if has_locked_grants($id) {
+        error('there are locked grants for this credential');
+    }
+    DELETE FROM credentials
+    WHERE id=$id
+    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = @caller)
+    );
+
+    DELETE FROM internal_access_grants WHERE data_id = $id;
+}
+
+// Do we need this procedure? Can share_credential_through_dag cover all cases?
+procedure share_credential(
+        $id uuid,
+        $original_credential_id uuid,
+        $credential_type text,
+        $credential_level text,
+        $credential_status text,
+        $content text,
+        $encryption_public_key text,
+        $issuer text) public {
+
+    if !credential_belongs_to_caller($original_credential_id) {
+        error('The original credential does not belong to the caller');
+    }
+
+    add_credential($id, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key, $issuer);
+    INSERT INTO shared_credentials (original_id, duplicate_id) VALUES ($original_credential_id, $id);
+}
+
+action share_credential_through_dag (
+        $id,
+        $human_id,
+        $original_credential_id,
+        $credential_type,
+        $credential_level,
+        $credential_status,
+        $content,
+        $encryption_public_key,
+        $issuer,
+        $dag_owner,
+        $dag_grantee,
+        $dag_locked_until,
+        $dag_signature) public {
+    SELECT CASE
+    WHEN NOT EXISTS (
+        SELECT 1 from credentials
+            WHERE id = $original_credential_id
+            AND human_id = $human_id
+    ) THEN ERROR('The original credential does not belong to the human') END;
+
+    $owner_verified = idos.verify_owner($dag_owner, $dag_grantee, $id, $dag_locked_until, $dag_signature);
+    SELECT CASE
+        WHEN $owner_verified != 1 THEN ERROR('the signature is invalid')
+    END;
+
+    SELECT CASE
+    WHEN NOT EXISTS (
+        SELECT 1 from humans
+            INNER JOIN wallets ON humans.id = wallets.human_id
+            WHERE wallet_type = 'EVM'
+            AND address=$dag_owner COLLATE NOCASE
+            AND human_id = $human_id
+    ) THEN ERROR('the DAG is not signed by the human') END;
+
+    INSERT INTO credentials (id, human_id, credential_type, credential_level, credential_status, content, encryption_public_key, issuer, inserter)
+        VALUES ($id, $human_id, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key, $issuer, get_inserter_or_null());
+    INSERT INTO shared_credentials (original_id, duplicate_id) VALUES ($original_credential_id, $id);
+}
+
+procedure share_credential_by_write_grant(
+    $id uuid,
+    $human_id uuid,
+    $original_credential_id uuid,
+    $credential_type text,
+    $credential_level text,
+    $credential_status text,
+    $content text,
+    $encryption_public_key text,
+    $grantee text,
+    $locked_until int,
+    $issuer text) public {
+
+    if $locked_until < 0 {
+        error('locked_until must be positive integer timestamp or zero');
+    }
+
+    $wg_id := get_write_grant_id($human_id); // throw an error if no write_grant
+
+    if !credential_belongs_to_human($original_credential_id, $human_id) {
+        error('the original credential does not belong to the human');
+    }
+
+    if $wg_id::TEXT != get_credential_inserter($original_credential_id) {
+        error('you can share only original credentials you created');
+    }
+
+    $generated_uuid := uuid_generate_v5('31276fd4-105f-4ff7-9f64-644942c14b79'::uuid, format('%s-%s-%s', $grantee, $original_credential_id, $locked_until));
+    for $row in SELECT 1 FROM internal_access_grants WHERE id = $generated_uuid LIMIT 1 {
+        error('a grant with the same grantee, original_credential_id, and locked_until already exists');
+    }
+
+    INSERT INTO credentials (id, human_id, credential_type, credential_level, credential_status, content, encryption_public_key, issuer, inserter)
+        VALUES ($id, $human_id, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key, $issuer, $wg_id::TEXT);
+
+    INSERT INTO shared_credentials (original_id, duplicate_id) VALUES ($original_credential_id, $id);
+
+    INSERT INTO internal_access_grants (id, ag_owner_human_id, ag_grantee, data_id, locked_until, write_grant_id)
+        VALUES (
+            $generated_uuid,
+            $human_id,
+            $grantee,
+            $id,
+            $locked_until,
+            $wg_id
+        );
+}
+
+@kgw(authn='true')
+procedure credential_exist_as_inserter($id uuid) public view returns (credential_exist bool) {
+    get_inserter();
+    return credential_exist($id);
+}
+
+// TODO: change to procedure
+@kgw(authn='true')
+action get_credential_owned ($id) public view {
+    SELECT DISTINCT credentials.*
+    FROM credentials
+    INNER JOIN wallets ON credentials.human_id = wallets.human_id
+    WHERE credentials.id = $id
+    AND (
+        (wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE)
+            OR (wallets.wallet_type = 'NEAR' AND wallets.public_key = @caller)
+    );
+}
+
+@kgw(authn='true')
+procedure get_credential_shared ($id uuid) public view returns table (id uuid, human_id uuid, credential_type text,
+    credential_level text, credential_status text, content text, encryption_public_key text, issuer text, inserter text) {
+    if !credential_exist($id) {
+        error('the credential does not exist');
+    }
+
+    $ext_ag_granted bool := false;
+    $ext_ag_grant_valid bool := false;
+    $int_ag_granted bool := false;
+
+    for $ext_ag_row in SELECT status FROM external_access_grants WHERE data_id = $id::TEXT AND ag_grantee = @caller COLLATE NOCASE {
+        $ext_ag_granted := true;
+        if $ext_ag_row.status == 'valid' {
+            $ext_ag_grant_valid := true;
+            break;
+        }
+    }
+
+    for $int_ag_row in SELECT 1 FROM internal_access_grants WHERE data_id = $id AND ag_grantee = @caller COLLATE NOCASE {
+        $int_ag_granted := true;
+    }
+
+    // We only keep valid internal AGs. So, we only need to double-check the validity for external AGs.
+    if !$int_ag_granted {
+        if !$ext_ag_granted {
+            error('the credential is not shared with the caller');
+        }
+
+        if !$ext_ag_grant_valid {
+            error('the credential has no valid access grant; for more details, call list_external_ag_statuses');
+        }
+    }
+
+    return SELECT id, human_id, credential_type, credential_level, credential_status, content, encryption_public_key,
+        issuer, inserter FROM credentials WHERE id = $id;
+}
+
+procedure credential_belongs_to_human($id uuid, $human_id uuid) private view returns (belongs bool) {
+    for $row in SELECT 1 from credentials WHERE id = $id AND human_id = $human_id LIMIT 1 {
+        return true;
+    }
+
+    return false;
+}
+
+procedure credential_belongs_to_caller($id uuid) private view returns (belongs bool) {
+    for $row in SELECT 1 from credentials
+        WHERE id = $id
+        AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = @caller)) {
+        return true;
+    }
+
+    return false;
+}
+
+procedure credential_exist($id uuid) private view returns (credential_exist bool) {
+    for $row in SELECT 1 FROM credentials WHERE id = $id {
+        return true;
+    }
+    return false;
+}
+
+procedure get_credential_inserter($id uuid) private view returns (inserter text) {
+    for $row in SELECT inserter FROM credentials WHERE id = $id LIMIT 1 {
+        return $row.inserter;
+    }
+
+    error('credential not found');
+}
+
+
+// ATTRUBITE ACTIONS
+
+procedure add_attribute_as_inserter($id uuid, $human_id uuid, $attribute_key text, $value text) public {
+    INSERT INTO human_attributes (id, human_id, attribute_key, value, inserter)
+    VALUES ($id, $human_id, $attribute_key, $value, get_inserter());
+}
+
+procedure add_attribute($id uuid, $attribute_key text, $value text) public {
+    INSERT INTO human_attributes (id, human_id, attribute_key, value)
+    VALUES (
+        $id,
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = @caller)
+        ),
+        $attribute_key,
+        $value
+    );
+}
+
+// TODO: change to procedure
+@kgw(authn='true')
+action get_attributes() public view {
+	SELECT DISTINCT ha.id, ha.human_id, ha.attribute_key, ha.value, sha.original_id AS original_id
+    FROM human_attributes AS ha
+    LEFT JOIN shared_human_attributes AS sha ON ha.id = sha.duplicate_id
+    INNER JOIN wallets ON ha.human_id = wallets.human_id
+    WHERE (
+        wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE
+    ) OR (
+        wallets.wallet_type = 'NEAR' AND wallets.public_key = @caller
+    );
+}
+
+// TODO: change to procedure
+action edit_attribute($id, $attribute_key, $value) public {
+    SELECT CASE
+        WHEN EXISTS (
+            SELECT 1 from human_attributes AS ha
+                INNER JOIN shared_human_attributes AS sha on ha.id = sha.duplicate_id
+                WHERE ha.id = $id
+                AND ha.human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+                    OR (wallet_type = 'NEAR' AND public_key = @caller))
+        ) THEN ERROR('Can not edit shared attribute') END;
+
+    UPDATE human_attributes
+    SET attribute_key=$attribute_key, value=$value
+    WHERE id=$id
+    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = @caller)
+    );
+}
+
+procedure remove_attribute($id uuid) public {
+    DELETE FROM human_attributes
+    WHERE id=$id
+    AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = @caller)
+    );
+}
+
+procedure share_attribute($id uuid, $original_attribute_id uuid, $attribute_key text, $value text) public {
+    INSERT INTO human_attributes (id, human_id, attribute_key, value)
+    VALUES (
+        $id,
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = @caller)
+        ),
+        $attribute_key,
+        $value
+    );
+
+    INSERT INTO shared_human_attributes (original_id, duplicate_id)
+    VALUES ($original_attribute_id, $id);
+}
+
+
+// EXTERNAL ACCESS GRANTS ACTIONS
+
+@kgw(authn='true')
+procedure list_external_ag_statuses($data_id text) public view returns table (ag_owner text, ag_grantee text, locked_until int, status text) {
+    return
+        SELECT ag_owner, ag_grantee, locked_until, status
+        FROM external_access_grants
+        WHERE data_id = $data_id
+          AND ag_grantee = @caller;
+}
+
+// This procedure is used in an oracle resolution to determine the status of a AG at the moment of adding it into idOS
+// It needs to be done at this moment because of later defining data can change (original credential deleted, owner wallet or profile removed etc.)
+procedure define_ag_status_as_owner($ag_owner text, $ag_grantee text, $data_id uuid) public view owner returns (status text) {
+    if !credential_exist($data_id) {
+        return 'invalid_data_id_not_found';
+    }
+
+    $data_id_is_duplicate := false;
+    for $row in SELECT 1 FROM shared_credentials WHERE duplicate_id = $data_id LIMIT 1 {
+        $data_id_is_duplicate := true;
+    }
+    if !$data_id_is_duplicate {
+        return 'invalid_data_id_is_not_a_duplicate';
+    }
+
+    for $row2 in SELECT 1 FROM wallets
+        INNER JOIN credentials ON credentials.human_id = wallets.human_id
+        WHERE credentials.id = $data_id
+        AND ((wallets.address = $ag_owner COLLATE NOCASE AND wallets.wallet_type = 'EVM')
+            OR (wallets.public_key = $ag_owner COLLATE NOCASE AND wallets.wallet_type = 'NEAR'))
+        LIMIT 1 {
+            return 'valid';
+        }
+
+    return 'invalid_ag_owner_does_not_match_original_credential_owner';
+}
+
+
+// WRITE GRANTS ACTIONS
+
+procedure add_write_grant($wg_grantee text) public {
+    INSERT INTO write_grants (id, wg_owner, wg_grantee, wg_owner_human_id) VALUES (
+        uuid_generate_v5('31276fd4-105f-4ff7-9f64-644942c14b79'::uuid, format('%s-%s', @caller, $wg_grantee)),
+        @caller,
+        $wg_grantee,
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = @caller)
+        )
+    );
+}
+
+procedure remove_write_grant($wg_grantee text) public {
+    DELETE FROM write_grants
+        WHERE wg_grantee = $wg_grantee COLLATE NOCASE
+        AND wg_owner_human_id = (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = @caller));
+}
+
+procedure get_write_grant_id($human_id uuid) private view returns (id uuid) {
+    for $row in SELECT id FROM write_grants WHERE wg_owner_human_id = $human_id AND wg_grantee = @caller COLLATE NOCASE LIMIT 1 {
+        return $row.id;
+    }
+
+    error('there is no write grant found');
+}
+
+
+// INTERNAL ACCESS GRANTS ACTIONS
+
+procedure revoke_internal_access_grant ($id uuid) public {
+    $iag_exist := false;
+    for $row in SELECT 1 FROM internal_access_grants WHERE id = $id
+        AND ag_owner_human_id = (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = @caller)) {
+        $iag_exist := true;
+    }
+
+    if !$iag_exist {
+        error('the internal access grant not found');
+    }
+
+    for $row2 in SELECT 1 FROM internal_access_grants WHERE id = $id
+        AND locked_until >= @block_timestamp
+        AND ag_owner_human_id = (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = @caller)) {
+        error('the grant is locked');
+    }
+
+    DELETE FROM internal_access_grants
+    WHERE id = $id
+    AND ag_owner_human_id = (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = @caller));
+}
+
+procedure get_internal_ag_owned () public view returns table (id uuid, ag_owner_human_id uuid,
+    ag_grantee text, data_id uuid, locked_until int, write_grant_id uuid) {
+    return SELECT id, ag_owner_human_id, ag_grantee, data_id, locked_until, write_grant_id FROM internal_access_grants
+        WHERE ag_owner_human_id = (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = @caller));
+}
+
+procedure get_internal_ag_granted () public view returns table (id uuid, ag_owner_human_id uuid,
+    ag_grantee text, data_id uuid, locked_until int) {
+    return SELECT id, ag_owner_human_id, ag_grantee, data_id, locked_until FROM internal_access_grants
+        WHERE ag_grantee =  @caller;
+}
+
+
+// BOTH GRANTS ACTIONS
+
+@kgw(authn='true')
+procedure has_locked_grants($id uuid) public view returns (has bool) {
+    for $ext_row in SELECT 1 FROM external_access_grants
+            WHERE data_id = $id::TEXT
+            AND ag_owner = @caller COLLATE NOCASE
+            AND status = 'valid'
+            AND locked_until >= @block_timestamp LIMIT 1 {
+        return true;
+    }
+
+    for $int_row in SELECT 1 FROM internal_access_grants
+            WHERE data_id = $id
+            AND ag_owner_human_id = (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+                OR (wallet_type = 'NEAR' AND public_key = @caller))
+            AND locked_until >= @block_timestamp LIMIT 1 {
+        return true;
+    }
+
+    return false;
+}
+
+
+// OTHER ACTIONS
+
+// Should we improve it to work with near wallets too?
+// TODO: change to procedure
+action has_profile($address) public view {
+    SELECT EXISTS (
+        SELECT 1 FROM wallets WHERE address=$address COLLATE NOCASE
+    ) AS has_profile;
+}
+
+
+// OWNER ACTIONS FOR MANUAL MIGRATIONS
+
+procedure insert_human_as_owner($id uuid, $current_public_key text, $inserter text) owner public {
+    INSERT INTO humans (id, current_public_key, inserter)
+    VALUES ($id, $current_public_key, $inserter);
+}
+
+procedure insert_wallet_as_owner($id uuid, $human_id uuid, $address text, $public_key text, $wallet_type text,
+    $message text, $signature text, $inserter text) owner public {
+    INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature, inserter)
+    VALUES ($id, $human_id, $address, $public_key, $wallet_type, $message, $signature, $inserter);
+}
+
+procedure insert_credential_as_owner($id uuid, $human_id uuid, $credential_type text, $credential_level text,
+    $credential_status text, $content text, $encryption_public_key text, $issuer text, $inserter text) owner public {
+    INSERT INTO credentials (id, human_id, credential_type, credential_level, credential_status, content,
+    encryption_public_key, issuer, inserter)
+    VALUES ($id, $human_id, $credential_type, $credential_level, $credential_status, $content,
+    $encryption_public_key, $issuer, $inserter);
+}
+
+procedure insert_shared_cred_as_owner($original_id uuid, $duplicate_id uuid) owner public {
+    INSERT INTO shared_credentials (original_id, duplicate_id)
+    VALUES ($original_id, $duplicate_id);
+}
+
+procedure insert_human_attribute_as_owner($id uuid, $human_id uuid, $attribute_key text, $value text, $inserter text) owner public {
+    INSERT INTO human_attributes (id, human_id, attribute_key, value, inserter)
+    VALUES ($id, $human_id, $attribute_key, $value, $inserter);
+}
+
+procedure insert_shared_attr_as_owner($original_id uuid, $duplicate_id uuid) owner public {
+    INSERT INTO shared_human_attributes (original_id, duplicate_id)
+    VALUES ($original_id, $duplicate_id);
+}
+
+// Some entities no need special actions because main actions do the same
+// inserters:  add_inserter_as_owner
+// delegates: add_delegate_as_owner
+// configs: upsert_config_as_owner
+
+procedure insert_external_ags_as_owner($id uuid, $ag_owner text, $ag_grantee text, $data_id text,
+    $locked_until int, $ag_chain text, $tx_hash text, $block_hash text, $height int, $status text
+    ) owner public {
+    INSERT INTO external_access_grants (id, ag_owner, ag_grantee, data_id, locked_until, ag_chain,
+        tx_hash, block_hash, height, status)
+    VALUES ($id, $ag_owner, $ag_grantee, $data_id, $locked_until, $ag_chain,
+        $tx_hash, $block_hash, $height, $status);
+}
+
+procedure insert_internal_ags_as_owner($id uuid, $ag_owner_human_id uuid, $ag_grantee text, $data_id uuid,
+    $locked_until int, $write_grant_id uuid) owner public {
+    INSERT INTO internal_access_grants (id, ag_owner_human_id, ag_grantee, data_id, locked_until, write_grant_id)
+    VALUES ($id, $ag_owner_human_id, $ag_grantee, $data_id, $locked_until, $write_grant_id);
+}
+
+procedure insert_write_grants_as_owner($id uuid, $wg_owner text, $wg_grantee text, $wg_owner_human_id uuid) owner public {
+    INSERT INTO write_grants (id, wg_owner, wg_grantee, wg_owner_human_id)
+    VALUES ($id, $wg_owner, $wg_grantee, $wg_owner_human_id);
+}
+
+
+// ACTIONS FOR IN-SCHEMA DATA MIGRATION (OWNER)
+
+procedure all_humans_as_owner() public view owner returns table (id uuid, current_public_key text, inserter text) {
+    return SELECT id, current_public_key, inserter FROM humans;
+}
+
+foreign procedure get_all_humans() returns table(id uuid, current_public_key text, inserter text)
+
+procedure migrate_humans($dbid text) public owner {
+    for $row in SELECT id, current_public_key, inserter FROM get_all_humans[$dbid, 'all_humans_as_owner']() {
+        INSERT INTO humans (id, current_public_key, inserter) VALUES ($row.id, $row.current_public_key, $row.inserter);
+    }
+}
+
+procedure all_wallets_as_owner() public view owner returns table (id uuid, human_id uuid, address text, public_key text,
+wallet_type text, message text, signature text, inserter text) {
+    return SELECT id, human_id, address, public_key, wallet_type, message, signature, inserter FROM wallets;
+}
+
+foreign procedure get_all_wallets() returns table (id uuid, human_id uuid, address text, public_key text,
+wallet_type text, message text, signature text, inserter text)
+
+procedure migrate_wallets($dbid text) public owner {
+    for $row in SELECT id, human_id, address, public_key, wallet_type, message, signature, inserter FROM get_all_wallets[$dbid, 'all_wallets_as_owner']() {
+        INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature, inserter)
+            VALUES ($row.id, $row.human_id, $row.address, $row.public_key, $row.wallet_type, $row.message, $row.signature, $row.inserter);
+    }
+}
+
+
+procedure all_credentials_as_owner() public view owner returns table (id uuid, human_id uuid, credential_type text,
+    credential_level text, credential_status text, content text, encryption_public_key text, issuer text, inserter text) {
+    return SELECT id, human_id, credential_type, credential_level, credential_status, content, encryption_public_key,
+        issuer, inserter FROM credentials;
+}
+
+foreign procedure get_all_credentials() returns table (id uuid, human_id uuid, credential_type text,
+credential_level text, credential_status text, content text, encryption_public_key text, issuer text, inserter text)
+
+procedure migrate_credentials($dbid text) public owner {
+    for $row in SELECT id, human_id, credential_type, credential_level, credential_status, content,
+        encryption_public_key, issuer, inserter FROM get_all_credentials[$dbid, 'all_credentials_as_owner']() {
+        INSERT INTO credentials (id, human_id, credential_type, credential_level, credential_status, content,
+            encryption_public_key, issuer, inserter)
+        VALUES ($row.id, $row.human_id, $row.credential_type, $row.credential_level, $row.credential_status, $row.content,
+            $row.encryption_public_key, $row.issuer, $row.inserter);
+    }
+}
+
+
+procedure all_shared_credentials_as_owner() public view owner returns table (original_id uuid, duplicate_id uuid) {
+    return SELECT original_id, duplicate_id FROM shared_credentials;
+}
+
+foreign procedure get_all_shared_credentials() returns table (original_id uuid, duplicate_id uuid)
+
+procedure migrate_shared_credentials($dbid text) public owner {
+    for $row in SELECT original_id, duplicate_id FROM get_all_shared_credentials[$dbid, 'all_shared_credentials_as_owner']() {
+        INSERT INTO shared_credentials (original_id, duplicate_id) VALUES ($row.original_id, $row.duplicate_id);
+    }
+}
+
+
+procedure all_human_attributes_as_owner() public view owner returns table (id uuid, human_id uuid, attribute_key text,
+    value text, inserter text) {
+    return SELECT id, human_id, attribute_key, value, inserter FROM human_attributes;
+}
+
+foreign procedure get_all_human_attributes() returns table (id uuid, human_id uuid, attribute_key text, value text, inserter text)
+
+procedure migrate_human_attributes($dbid text) public owner {
+    for $row in SELECT id, human_id, attribute_key, value, inserter FROM get_all_human_attributes[$dbid, 'all_human_attributes_as_owner']() {
+        INSERT INTO human_attributes (id, human_id, attribute_key, value, inserter)
+        VALUES ($row.id, $row.human_id, $row.attribute_key, $row.value, $row.inserter);
+    }
+}
+
+
+procedure all_shared_human_attrs_as_owner() public view owner returns table (original_id uuid, duplicate_id uuid) {
+    return SELECT original_id, duplicate_id FROM shared_human_attributes;
+}
+
+foreign procedure get_all_shared_human_attrs() returns table (original_id uuid, duplicate_id uuid)
+
+procedure migrate_shared_human_attrs($dbid text) public owner {
+    for $row in SELECT original_id, duplicate_id FROM get_all_shared_human_attrs[$dbid, 'all_shared_human_attrs_as_owner']() {
+        INSERT INTO shared_human_attributes (original_id, duplicate_id) VALUES ($row.original_id, $row.duplicate_id);
+    }
+}
+
+
+procedure all_inserters_as_owner() public view owner returns table (id uuid, name text) {
+    return SELECT id, name FROM inserters;
+}
+
+foreign procedure get_all_inserters() returns table (id uuid, name text)
+
+procedure migrate_inserters($dbid text) public owner {
+    for $row in SELECT id, name FROM get_all_inserters[$dbid, 'all_inserters_as_owner']() {
+        INSERT INTO inserters (id, name) VALUES ($row.id, $row.name);
+    }
+}
+
+
+procedure all_delegates_as_owner() public view owner returns table (address text, inserter_id uuid) {
+    return SELECT address, inserter_id FROM delegates;
+}
+
+foreign procedure get_all_delegates() returns table (address text, inserter_id uuid)
+
+procedure migrate_delegates($dbid text) public owner {
+    for $row in SELECT address, inserter_id FROM get_all_delegates[$dbid, 'all_delegates_as_owner']() {
+        INSERT INTO delegates (address, inserter_id) VALUES ($row.address, $row.inserter_id);
+    }
+}
+
+
+procedure all_external_grants_as_owner() public view owner returns table (id uuid, ag_owner text, ag_grantee text,
+    data_id text, locked_until int, ag_chain text, tx_hash text, height int, block_hash text) {
+    return SELECT id, ag_owner, ag_grantee, data_id, locked_until, ag_chain, tx_hash, height, block_hash FROM external_access_grants;
+}
+
+foreign procedure get_all_external_grants() returns table (id uuid, ag_owner text, ag_grantee text,
+    data_id text, locked_until int, ag_chain text, tx_hash text, height int, block_hash text)
+
+procedure migrate_external_grants($dbid text) public owner {
+    for $row in SELECT id, ag_owner, ag_grantee, data_id, locked_until, ag_chain, tx_hash, height, block_hash
+        FROM get_all_external_grants[$dbid, 'all_grants_as_owner']() { // TODO Change this to all_external_grants_as_owner after migration
+        INSERT INTO external_access_grants (id, ag_owner, ag_grantee, data_id, locked_until, ag_chain, tx_hash, height, block_hash)
+            VALUES ($row.id, $row.ag_owner, $row.ag_grantee, $row.data_id, $row.locked_until, $row.ag_chain,
+            $row.tx_hash, $row.height, $row.block_hash);
+    }
+}
+
+
+procedure all_internal_grants_as_owner() public view owner returns table (id uuid, ag_owner_human_id uuid, ag_grantee text,
+    data_id uuid, locked_until int, write_grant_id uuid) {
+    return SELECT id, ag_owner_human_id, ag_grantee, data_id, locked_until, write_grant_id FROM internal_access_grants;
+}
+
+foreign procedure get_all_internal_grants() returns table (id uuid, ag_owner_human_id uuid, ag_grantee text,
+    data_id uuid, locked_until int, write_grant_id uuid)
+
+procedure migrate_internal_grants($dbid text) public owner {
+    for $row in SELECT id, ag_owner_human_id, ag_grantee, data_id, locked_until, write_grant_id
+        FROM get_all_internal_grants[$dbid, 'all_internal_grants_as_owner']() {
+        INSERT INTO internal_access_grants (id, ag_owner_human_id, ag_grantee, data_id, locked_until, write_grant_id)
+            VALUES ($row.id, $row.ag_owner_human_id, $row.ag_grantee, $row.data_id, $row.locked_until, $row.write_grant_id);
+    }
+}
+
+
+procedure all_write_grants_as_owner() public view owner returns table (id uuid, wg_owner text, wg_grantee text,
+    wg_owner_human_id uuid) {
+    return SELECT id, wg_owner, wg_grantee, wg_owner_human_id FROM write_grants;
+}
+
+foreign procedure get_all_write_grants() returns table (id uuid, wg_owner text, wg_grantee text, wg_owner_human_id uuid)
+
+procedure migrate_write_grants($dbid text) public owner {
+    for $row in SELECT id, wg_owner, wg_grantee, wg_owner_human_id FROM get_all_write_grants[$dbid, 'all_write_grants_as_owner']() {
+        INSERT INTO write_grants (id, wg_owner, wg_grantee, wg_owner_human_id)
+            VALUES ($row.id, $row.wg_owner, $row.wg_grantee, $row.wg_owner_human_id);
+    }
+}
+
+
+procedure all_configs_as_owner() public view owner returns table (config_key text, value text) {
+    return SELECT config_key, value FROM configs;
+}
+
+foreign procedure get_all_configs() returns table (config_key text, value text)
+
+procedure migrate_configs($dbid text) public owner {
+    for $row in SELECT config_key, value FROM get_all_configs[$dbid, 'all_configs_as_owner']() {
+        INSERT INTO configs (config_key, value)
+            VALUES ($row.config_key, $row.value);
+    }
+}
+
+// The sequence of inserting of tables is important
+procedure migrate_all_data($old_dbid text) public owner {
+    migrate_humans($old_dbid);
+    migrate_wallets($old_dbid);
+    migrate_credentials($old_dbid);
+    migrate_shared_credentials($old_dbid);
+    migrate_human_attributes($old_dbid);
+    migrate_shared_human_attrs($old_dbid);
+    migrate_inserters($old_dbid);
+    migrate_delegates($old_dbid);
+    migrate_external_grants($old_dbid);
+    // migrate_write_grants($old_dbid); // WGs must be inserted before internal AGs
+    // migrate_internal_grants($old_dbid);
+    migrate_configs($old_dbid);
+}

--- a/schema.development_temp.kf
+++ b/schema.development_temp.kf
@@ -354,7 +354,7 @@ procedure add_credential_by_write_grant(
 // TODO: change to procedure
 @kgw(authn='true')
 action get_credentials() public view {
-	SELECT DISTINCT c.id, c.human_id, c.inserter, c.credential_type, c.credential_level, c.credential_status, c.issuer, sc.original_id AS original_id
+    SELECT DISTINCT c.id, c.human_id, c.inserter, c.credential_type, c.credential_level, c.credential_status, c.issuer, sc.original_id AS original_id
     FROM credentials AS c
     LEFT JOIN shared_credentials AS sc ON c.id = sc.duplicate_id
     INNER JOIN wallets ON c.human_id = wallets.human_id
@@ -623,7 +623,7 @@ procedure add_attribute($id uuid, $attribute_key text, $value text) public {
 // TODO: change to procedure
 @kgw(authn='true')
 action get_attributes() public view {
-	SELECT DISTINCT ha.id, ha.human_id, ha.attribute_key, ha.value, sha.original_id AS original_id
+    SELECT DISTINCT ha.id, ha.human_id, ha.attribute_key, ha.value, sha.original_id AS original_id
     FROM human_attributes AS ha
     LEFT JOIN shared_human_attributes AS sha ON ha.id = sha.duplicate_id
     INNER JOIN wallets ON ha.human_id = wallets.human_id

--- a/schema.playground.kf
+++ b/schema.playground.kf
@@ -354,7 +354,7 @@ procedure add_credential_by_write_grant(
 // TODO: change to procedure
 @kgw(authn='true')
 action get_credentials() public view {
-	SELECT DISTINCT c.id, c.human_id, c.inserter, c.credential_type, c.credential_level, c.credential_status, c.issuer, sc.original_id AS original_id
+    SELECT DISTINCT c.id, c.human_id, c.inserter, c.credential_type, c.credential_level, c.credential_status, c.issuer, sc.original_id AS original_id
     FROM credentials AS c
     LEFT JOIN shared_credentials AS sc ON c.id = sc.duplicate_id
     INNER JOIN wallets ON c.human_id = wallets.human_id
@@ -623,7 +623,7 @@ procedure add_attribute($id uuid, $attribute_key text, $value text) public {
 // TODO: change to procedure
 @kgw(authn='true')
 action get_attributes() public view {
-	SELECT DISTINCT ha.id, ha.human_id, ha.attribute_key, ha.value, sha.original_id AS original_id
+    SELECT DISTINCT ha.id, ha.human_id, ha.attribute_key, ha.value, sha.original_id AS original_id
     FROM human_attributes AS ha
     LEFT JOIN shared_human_attributes AS sha ON ha.id = sha.duplicate_id
     INNER JOIN wallets ON ha.human_id = wallets.human_id

--- a/schema.playground.kf
+++ b/schema.playground.kf
@@ -2,25 +2,8 @@ database idos;
 
 // EXTENSION INITIALIZATION
 
-use idos {
-    registry_address: '0x11Fe2099B205388ED95BB0e52e424512eb43692f',
-    chain: 'eth'
-} as idos_eth;
+use idos as idos;
 
-use idos {
-    registry_address: 'idos-dev-2.testnet',
-    chain: 'near'
-} as idos_near;
-
-use idos {
-    registry_address: '0x350829c8FCb3DF16EeaE9ADDa2565090348426f9',
-    chain: 'arbitrum'
-} as idos_arbitrum;
-
-use idos {
-    registry_address: '0xeed5537b68baD728A3Bb433d8e06ebab81ac0EAB',
-    chain: 'etherlink'
-} as idos_etherlink;
 
 // TABLES
 
@@ -63,6 +46,7 @@ table shared_credentials {
     original_id uuid notnull,
     duplicate_id uuid notnull,
     #primary_key primary(original_id, duplicate_id),
+    #shared_credentials_duplicate_id index(duplicate_id),
     foreign_key (original_id) references credentials(id) on_delete cascade,
     foreign_key (duplicate_id) references credentials(id) on_delete cascade
 }
@@ -96,8 +80,47 @@ table delegates {
     foreign_key (inserter_id) references inserters(id) on_delete cascade
 }
 
+table access_grants {
+    id uuid primary,
+    ag_owner text notnull,
+    ag_grantee text notnull,
+    data_id text notnull,
+    locked_until int,
+    ag_chain text notnull,
+    tx_hash text,
+    block_hash text,
+    height int,
+    status text,
+    #access_grants_data_id_grantee index(data_id, ag_grantee),
+    #access_grants_data_id_owner index(data_id, ag_owner)
+}
 
-// inserter AND DELEGATE ACTIONS
+table configs {
+    config_key text primary,
+    value text
+}
+
+
+// CONFIG ACTIONS
+
+procedure upsert_config_as_owner($config_key text, $value text) public owner {
+    INSERT INTO configs (config_key, value) VALUES ($config_key, $value)
+        ON CONFLICT(config_key) DO UPDATE
+            SET value = $value;
+}
+
+procedure delete_config_as_owner($config_key text) public owner {
+    DELETE FROM configs WHERE config_key = $config_key;
+}
+
+procedure get_config_as_owner($config_key text) public view owner returns (value text) {
+    for $row in SELECT config_key, value FROM configs WHERE config_key = $config_key {
+        return $row.value;
+    }
+}
+
+
+// INSERTER AND DELEGATE ACTIONS
 
 procedure add_inserter_as_owner($id uuid, $name text) owner public {
     INSERT INTO inserters (id, name) VALUES ($id, $name);
@@ -150,18 +173,17 @@ procedure delete_human_as_owner($id uuid) public owner {
 // DEPRECATED
 @kgw(authn='true')
 action get_wallet_human_id() public view {
-    $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT DISTINCT human_id FROM wallets
     WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted);
+        OR (wallet_type = 'NEAR' AND public_key = @caller);
 }
 
+// TODO: change to procedure
 @kgw(authn='true')
 action get_human() public view {
-    $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT id, current_public_key FROM humans
     WHERE id = (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted));
+        OR (wallet_type = 'NEAR' AND public_key = @caller));
 }
 
 @kgw(authn='true')
@@ -175,11 +197,12 @@ procedure get_human_as_inserter($id uuid) public view returns (id uuid, current_
 
 // WALLET ACTIONS
 
+// TODO: change to procedure
 action upsert_wallet_as_inserter($id, $human_id, $address, $public_key, $wallet_type, $message, $signature) public {
     SELECT CASE WHEN $wallet_type = 'NEAR' AND $public_key::TEXT IS NULL THEN ERROR('NEAR wallets require a public_key to be given.') END;
 
-    $valid_near_public_key = idos_near.is_valid_public_key($public_key);
-    SELECT CASE WHEN $wallet_type = 'NEAR' AND $valid_near_public_key != 1 THEN ERROR('Invalid or unsupported public key.') END;
+    $valid_public_key = idos.is_valid_public_key($public_key, $wallet_type);
+    SELECT CASE WHEN $wallet_type = 'NEAR' AND $valid_public_key != 1 THEN ERROR('Invalid or unsupported public key.') END;
 
     INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature, inserter)
     VALUES ($id, $human_id, $address, $public_key, $wallet_type, $message, $signature, get_inserter())
@@ -192,20 +215,20 @@ procedure delete_wallet_as_owner($id uuid) public owner {
     DELETE FROM wallets WHERE id=$id;
 }
 
+// Do we need to ask user/sdk to provide id? It is possible now to generate the `id` in the procedure in consensus way
 action add_wallet($id, $address, $public_key, $message, $signature) public {
-    $converted = idos_near.implicit_address_to_public_key(@caller);
-    $wallet_type = idos_near.determine_wallet_type($address);
+    $wallet_type = idos.determine_wallet_type($address);
 
     SELECT CASE WHEN $wallet_type = 'NEAR' AND $public_key::TEXT IS NULL THEN ERROR('NEAR wallets require a public_key to be given.') END;
 
-    $valid_near_public_key = idos_near.is_valid_public_key($public_key);
-    SELECT CASE WHEN $wallet_type = 'NEAR' AND $valid_near_public_key != 1 THEN ERROR('Invalid or unsupported public key.') END;
+    $valid_public_key = idos.is_valid_public_key($public_key, $wallet_type);
+    SELECT CASE WHEN $wallet_type = 'NEAR' AND $valid_public_key != 1 THEN ERROR('Invalid or unsupported public key.') END;
 
     INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
     VALUES (
         $id,
         (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-            OR (wallet_type = 'NEAR' AND public_key = $converted)
+            OR (wallet_type = 'NEAR' AND public_key = @caller)
         ),
         $address,
         CASE
@@ -218,31 +241,34 @@ action add_wallet($id, $address, $public_key, $message, $signature) public {
     );
 }
 
+// TODO: change to procedure
 @kgw(authn='true')
 action get_wallets() public view {
-    $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT DISTINCT w1.*
     FROM wallets AS w1
     INNER JOIN wallets AS w2 ON w1.human_id = w2.human_id
     WHERE (
         w2.wallet_type = 'EVM' AND w2.address = @caller COLLATE NOCASE
     ) OR (
-        w2.wallet_type = 'NEAR' AND w2.public_key = $converted
+        w2.wallet_type = 'NEAR' AND w2.public_key = @caller
     );
 }
 
-action remove_wallet($id) public {
-    $converted = idos_near.implicit_address_to_public_key(@caller);
-    SELECT CASE
-    WHEN EXISTS (SELECT count(id) FROM wallets
-        WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE) OR (wallet_type = 'NEAR' AND public_key = $converted)
-        GROUP BY address HAVING count(id) = 1)
-    THEN ERROR('A human needs to have at least one wallet. We can not delete the last wallet.')
-    END;
+procedure remove_wallet($id uuid) public {
+    for $row in SELECT id FROM wallets
+        WHERE id = $id
+        AND ((wallet_type = 'EVM' AND address=@caller COLLATE NOCASE) OR (wallet_type = 'NEAR' AND public_key = @caller))
+        AND EXISTS (
+            SELECT count(id) FROM wallets
+                WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE) OR (wallet_type = 'NEAR' AND public_key = @caller)
+                GROUP BY human_id HAVING count(id) = 1
+        ) {
+        error('You can not delete a wallet you are connected with. To delete this wallet you have to connect other wallet.');
+    }
 
     DELETE FROM wallets
     WHERE id=$id AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted)
+        OR (wallet_type = 'NEAR' AND public_key = @caller)
     );
 }
 
@@ -264,16 +290,17 @@ procedure upsert_credential_as_inserter(
     ON CONFLICT(id) DO UPDATE
     SET credential_status=$credential_status, content=$content, encryption_public_key=$encryption_public_key, issuer=$issuer, inserter=$inserter;
 
+    // Do we still need this return?
     return true; // dummy return value is needed when the procedure is called from an action like `SELECT procedure_call()`;
 }
 
-action add_credential($id, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key, $issuer) public {
-    $converted = idos_near.implicit_address_to_public_key(@caller);
+procedure add_credential($id uuid, $credential_type text, $credential_level text, $credential_status text, $content text,
+    $encryption_public_key text, $issuer text) public {
     INSERT INTO credentials (id, human_id, credential_type, credential_level, credential_status, content, encryption_public_key, issuer)
     VALUES (
         $id,
         (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-            OR (wallet_type = 'NEAR' AND public_key = $converted)
+            OR (wallet_type = 'NEAR' AND public_key = @caller)
         ),
         $credential_type,
         $credential_level,
@@ -284,9 +311,9 @@ action add_credential($id, $credential_type, $credential_level, $credential_stat
     );
 }
 
+// TODO: change to procedure
 @kgw(authn='true')
 action get_credentials() public view {
-    $converted = idos_near.implicit_address_to_public_key(@caller);
 	SELECT DISTINCT c.id, c.human_id, c.inserter, c.credential_type, c.credential_level, c.credential_status, sc.original_id AS original_id
     FROM credentials AS c
     LEFT JOIN shared_credentials AS sc ON c.id = sc.duplicate_id
@@ -294,19 +321,19 @@ action get_credentials() public view {
     WHERE (
         wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE
     ) OR (
-        wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted
+        wallets.wallet_type = 'NEAR' AND wallets.public_key = @caller
     );
 }
 
+// TODO: change to procedure
 action edit_credential($id, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key, $issuer) public {
-    $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT CASE
         WHEN EXISTS (
             SELECT 1 from credentials AS c
                 INNER JOIN shared_credentials AS sc on c.id = sc.duplicate_id
                 WHERE c.id = $id
                 AND c.human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-                    OR (wallet_type = 'NEAR' AND public_key = $converted))
+                    OR (wallet_type = 'NEAR' AND public_key = @caller))
         ) THEN ERROR('Can not edit shared credential') END;
 
     UPDATE credentials
@@ -314,47 +341,49 @@ action edit_credential($id, $credential_type, $credential_level, $credential_sta
         content=$content, encryption_public_key=$encryption_public_key, issuer=$issuer
     WHERE id=$id
     AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted)
+        OR (wallet_type = 'NEAR' AND public_key = @caller)
     );
 }
 
-action remove_credential($id) public {
-    $has_locked_grants_eth = idos_eth.has_locked_grants(@caller, $id);
-    $has_locked_grants_near = idos_near.has_locked_grants(@caller, $id);
-    $has_locked_grants_arbitrum = idos_arbitrum.has_locked_grants(@caller, $id);
-    $has_locked_grants_etherlink = idos_etherlink.has_locked_grants(@caller, $id);
-    SELECT CASE
-        WHEN $has_locked_grants_eth = 1 OR $has_locked_grants_near = 1 OR $has_locked_grants_arbitrum = 1 OR $has_locked_grants_etherlink = 1
-        THEN ERROR('there are locked grants for this credential') END;
-
-    $converted = idos_near.implicit_address_to_public_key(@caller);
+procedure remove_credential($id uuid) public {
+    if has_locked_grants($id) {
+        error('there are locked grants for this credential');
+    }
     DELETE FROM credentials
     WHERE id=$id
     AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted)
+        OR (wallet_type = 'NEAR' AND public_key = @caller)
     );
 }
 
-action share_credential(
-        $id,
-        $original_credential_id,
-        $credential_type,
-        $credential_level,
-        $credential_status,
-        $content,
-        $encryption_public_key,
-        $issuer) public {
-    $converted = idos_near.implicit_address_to_public_key(@caller);
-    SELECT CASE
-    WHEN NOT EXISTS (
-        SELECT 1 from credentials
-            WHERE id = $original_credential_id
-            AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-                OR (wallet_type = 'NEAR' AND public_key = $converted))
-    ) THEN ERROR('The original credential does not belong to the caller') END;
+// Do we need this procedure? Can share_credential_through_dag cover all cases?
+procedure share_credential(
+        $id uuid,
+        $original_credential_id uuid,
+        $credential_type text,
+        $credential_level text,
+        $credential_status text,
+        $content text,
+        $encryption_public_key text,
+        $issuer text) public {
+
+    if !credential_belongs_to_human($original_credential_id) {
+        error('The original credential does not belong to the caller');
+    }
 
     add_credential($id, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key, $issuer);
     INSERT INTO shared_credentials (original_id, duplicate_id) VALUES ($original_credential_id, $id);
+}
+
+procedure credential_belongs_to_human($id uuid) private returns (belongs bool) {
+    for $row in SELECT 1 from credentials
+        WHERE id = $id
+        AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = @caller)) {
+        return true;
+    }
+
+    return false;
 }
 
 action share_credential_through_dag (
@@ -378,7 +407,7 @@ action share_credential_through_dag (
             AND human_id = $human_id
     ) THEN ERROR('The original credential does not belong to the human') END;
 
-    $owner_verified = idos_eth.verify_owner($dag_owner, $dag_grantee, $id, $dag_locked_until, $dag_signature);
+    $owner_verified = idos.verify_owner($dag_owner, $dag_grantee, $id, $dag_locked_until, $dag_signature);
     SELECT CASE
         WHEN $owner_verified != 1 THEN ERROR('the signature is invalid')
     END;
@@ -400,39 +429,57 @@ action share_credential_through_dag (
 @kgw(authn='true')
 procedure credential_exist_as_inserter($id uuid) public view returns (credential_exist bool) {
     get_inserter();
-    for $row in SELECT 1 FROM credentials WHERE id = $id {
-        return true;
-    }
-    return false;
+    return credential_exist($id);
 }
 
+// TODO: change to procedure
 @kgw(authn='true')
 action get_credential_owned ($id) public view {
-    $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT DISTINCT credentials.*
     FROM credentials
     INNER JOIN wallets ON credentials.human_id = wallets.human_id
     WHERE credentials.id = $id
     AND (
         (wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE)
-            OR (wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted)
+            OR (wallets.wallet_type = 'NEAR' AND wallets.public_key = @caller)
     );
 }
 
 @kgw(authn='true')
-action get_credential_shared ($id) public view {
-    $has_grant_on_eth = idos_eth.has_grants(@caller, $id);
-    $has_grant_on_near = idos_near.has_grants(@caller, $id);
-    $has_grant_on_arbitrum = idos_arbitrum.has_grants(@caller, $id);
-    $has_grant_on_etherlink = idos_etherlink.has_grants(@caller, $id);
+procedure get_credential_shared ($id uuid) public view returns table (id uuid, human_id uuid, credential_type text,
+    credential_level text, credential_status text, content text, encryption_public_key text, issuer text, inserter text) {
+    if !credential_exist($id) {
+        error('the credential does not exist');
+    }
 
-    SELECT CASE
-        WHEN $has_grant_on_eth != 1 AND $has_grant_on_near != 1 AND $has_grant_on_arbitrum != 1 AND $has_grant_on_etherlink != 1
-        THEN ERROR('caller does not have access') END;
+    $granted bool := false;
+    $grant_valid bool := false;
 
-    SELECT *
-    FROM credentials
-    WHERE id = $id;
+    for $row in SELECT status FROM access_grants WHERE data_id = $id::TEXT AND ag_grantee = @caller COLLATE NOCASE {
+        $granted := true;
+        if $row.status == 'valid' {
+            $grant_valid := true;
+            break;
+        }
+    }
+
+    if !$granted {
+        error('the credential is not shared with the caller');
+    }
+
+    if !$grant_valid {
+        error('the credential has no valid access grant; for more details, call list_ag_statuses');
+    }
+
+    return SELECT id, human_id, credential_type, credential_level, credential_status, content, encryption_public_key,
+        issuer, inserter FROM credentials WHERE id = $id;
+}
+
+procedure credential_exist($id uuid) private view returns (credential_exist bool) {
+    for $row in SELECT 1 FROM credentials WHERE id = $id {
+        return true;
+    }
+    return false;
 }
 
 
@@ -443,22 +490,21 @@ procedure add_attribute_as_inserter($id uuid, $human_id uuid, $attribute_key tex
     VALUES ($id, $human_id, $attribute_key, $value, get_inserter());
 }
 
-action add_attribute($id, $attribute_key, $value) public {
-    $converted = idos_near.implicit_address_to_public_key(@caller);
+procedure add_attribute($id uuid, $attribute_key text, $value text) public {
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
     VALUES (
         $id,
         (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-            OR (wallet_type = 'NEAR' AND public_key = $converted)
+            OR (wallet_type = 'NEAR' AND public_key = @caller)
         ),
         $attribute_key,
         $value
     );
 }
 
+// TODO: change to procedure
 @kgw(authn='true')
 action get_attributes() public view {
-    $converted = idos_near.implicit_address_to_public_key(@caller);
 	SELECT DISTINCT ha.id, ha.human_id, ha.attribute_key, ha.value, sha.original_id AS original_id
     FROM human_attributes AS ha
     LEFT JOIN shared_human_attributes AS sha ON ha.id = sha.duplicate_id
@@ -466,45 +512,43 @@ action get_attributes() public view {
     WHERE (
         wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE
     ) OR (
-        wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted
+        wallets.wallet_type = 'NEAR' AND wallets.public_key = @caller
     );
 }
 
+// TODO: change to procedure
 action edit_attribute($id, $attribute_key, $value) public {
-    $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT CASE
         WHEN EXISTS (
             SELECT 1 from human_attributes AS ha
                 INNER JOIN shared_human_attributes AS sha on ha.id = sha.duplicate_id
                 WHERE ha.id = $id
                 AND ha.human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-                    OR (wallet_type = 'NEAR' AND public_key = $converted))
+                    OR (wallet_type = 'NEAR' AND public_key = @caller))
         ) THEN ERROR('Can not edit shared attribute') END;
 
     UPDATE human_attributes
     SET attribute_key=$attribute_key, value=$value
     WHERE id=$id
     AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted)
+        OR (wallet_type = 'NEAR' AND public_key = @caller)
     );
 }
 
-action remove_attribute($id) public {
-    $converted = idos_near.implicit_address_to_public_key(@caller);
+procedure remove_attribute($id uuid) public {
     DELETE FROM human_attributes
     WHERE id=$id
     AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted)
+        OR (wallet_type = 'NEAR' AND public_key = @caller)
     );
 }
 
-action share_attribute($id, $original_attribute_id, $attribute_key, $value) public {
-    $converted = idos_near.implicit_address_to_public_key(@caller);
+procedure share_attribute($id uuid, $original_attribute_id uuid, $attribute_key text, $value text) public {
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
     VALUES (
         $id,
         (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-            OR (wallet_type = 'NEAR' AND public_key = $converted)
+            OR (wallet_type = 'NEAR' AND public_key = @caller)
         ),
         $attribute_key,
         $value
@@ -515,9 +559,61 @@ action share_attribute($id, $original_attribute_id, $attribute_key, $value) publ
 }
 
 
+// ACCEESS GRANTS ACTIONS
+
+@kgw(authn='true')
+procedure list_ag_statuses($data_id text) public view returns table (ag_owner text, ag_grantee text, locked_until int, status text) {
+    return
+        SELECT ag_owner, ag_grantee, locked_until, status
+        FROM access_grants
+        WHERE data_id = $data_id
+          AND ag_grantee = @caller;
+}
+
+@kgw(authn='true')
+procedure has_locked_grants($id uuid) public view returns (has bool) {
+    for $row in SELECT 1 FROM access_grants
+            WHERE data_id = $id::TEXT
+            AND ag_owner = @caller COLLATE NOCASE
+            AND status = 'valid'
+            AND locked_until >= @block_timestamp LIMIT 1 {
+        return true;
+    }
+    return false;
+}
+
+// This procedure is used in an oracle resolution to determine the status of a AG at the moment of adding it into idOS
+// It needs to be done at this moment because of later defining data can change (original credential deleted, owner wallet or profile removed etc.)
+procedure define_ag_status_as_owner($ag_owner text, $ag_grantee text, $data_id uuid) public view owner returns (status text) {
+    if !credential_exist($data_id) {
+        return 'invalid_data_id_not_found';
+    }
+
+    $data_id_is_duplicate := false;
+    for $row in SELECT 1 FROM shared_credentials WHERE duplicate_id = $data_id LIMIT 1 {
+        $data_id_is_duplicate := true;
+    }
+    if !$data_id_is_duplicate {
+        return 'invalid_data_id_is_not_a_duplicate';
+    }
+
+    for $row2 in SELECT 1 FROM wallets
+        INNER JOIN credentials ON credentials.human_id = wallets.human_id
+        WHERE credentials.id = $data_id
+        AND ((wallets.address = $ag_owner COLLATE NOCASE AND wallets.wallet_type = 'EVM')
+            OR (wallets.public_key = $ag_owner COLLATE NOCASE AND wallets.wallet_type = 'NEAR'))
+        LIMIT 1 {
+            return 'valid';
+        }
+
+    return 'invalid_ag_owner_does_not_match_original_credential_owner';
+}
+
+
 // OTHER ACTIONS
 
 // Should we improve it to work with near wallets too?
+// TODO: change to procedure
 action has_profile($address) public view {
     SELECT EXISTS (
         SELECT 1 FROM wallets WHERE address=$address COLLATE NOCASE
@@ -525,7 +621,7 @@ action has_profile($address) public view {
 }
 
 
-// OWNER ACTIONS FOR MIGRATIONS
+// OWNER ACTIONS FOR MANUAL MIGRATIONS
 
 procedure insert_human_as_owner($id uuid, $current_public_key text, $inserter text) owner public {
     INSERT INTO humans (id, current_public_key, inserter)
@@ -533,13 +629,13 @@ procedure insert_human_as_owner($id uuid, $current_public_key text, $inserter te
 }
 
 procedure insert_wallet_as_owner($id uuid, $human_id uuid, $address text, $public_key text, $wallet_type text,
-$message text, $signature text, $inserter text) owner public {
+    $message text, $signature text, $inserter text) owner public {
     INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature, inserter)
     VALUES ($id, $human_id, $address, $public_key, $wallet_type, $message, $signature, $inserter);
 }
 
 procedure insert_credential_as_owner($id uuid, $human_id uuid, $credential_type text, $credential_level text,
-$credential_status text, $content text, $encryption_public_key text, $issuer text, $inserter text) owner public {
+    $credential_status text, $content text, $encryption_public_key text, $issuer text, $inserter text) owner public {
     INSERT INTO credentials (id, human_id, credential_type, credential_level, credential_status, content,
     encryption_public_key, issuer, inserter)
     VALUES ($id, $human_id, $credential_type, $credential_level, $credential_status, $content,
@@ -559,4 +655,51 @@ procedure insert_human_attribute_as_owner($id uuid, $human_id uuid, $attribute_k
 procedure insert_shared_attr_as_owner($original_id uuid, $duplicate_id uuid) owner public {
     INSERT INTO shared_human_attributes (original_id, duplicate_id)
     VALUES ($original_id, $duplicate_id);
+}
+
+// ACTIONS FOR IN-SCHEMA DATA MIGRATION
+
+procedure all_humans_as_owner() public view owner returns table (id uuid, current_public_key text, inserter text){
+    return SELECT id, current_public_key, inserter FROM humans;
+}
+
+procedure all_wallets_as_owner() public view owner returns table (id uuid, human_id uuid, address text, public_key text,
+    wallet_type text, message text, signature text, inserter text) {
+    return SELECT id, human_id, address, public_key, wallet_type, message, signature, inserter FROM wallets;
+}
+
+procedure all_credentials_as_owner() public view owner returns table (id uuid, human_id uuid, credential_type text,
+    credential_level text, credential_status text, content text, encryption_public_key text, issuer text, inserter text) {
+    return SELECT id, human_id, credential_type, credential_level, credential_status, content, encryption_public_key,
+        issuer, inserter FROM credentials;
+}
+
+procedure all_shared_credentials_as_owner() public view owner returns table (original_id uuid, duplicate_id uuid) {
+    return SELECT original_id, duplicate_id FROM shared_credentials;
+}
+
+procedure all_human_attributes_as_owner() public view owner returns table (id uuid, human_id uuid, attribute_key text,
+    value text, inserter text) {
+    return SELECT id, human_id, attribute_key, value, inserter FROM human_attributes;
+}
+
+procedure all_shared_human_attrs_as_owner() public view owner returns table (original_id uuid, duplicate_id uuid) {
+    return SELECT original_id, duplicate_id FROM shared_human_attributes;
+}
+
+procedure all_inserters_as_owner() public view owner returns table (id uuid, name text) {
+    return SELECT id, name FROM inserters;
+}
+
+procedure all_delegates_as_owner() public view owner returns table (address text, inserter_id uuid) {
+    return SELECT address, inserter_id FROM delegates;
+}
+
+procedure all_grants_as_owner() public view owner returns table (id uuid, ag_owner text, ag_grantee text,
+    data_id text, locked_until int, ag_chain text, tx_hash text, height int, block_hash text) {
+    return SELECT id, ag_owner, ag_grantee, data_id, locked_until, ag_chain, tx_hash, height, block_hash FROM access_grants;
+}
+
+procedure all_configs_as_owner () public view owner returns table (config_key text, value text) {
+    return SELECT config_key, value FROM configs;
 }

--- a/schema.playground.kf
+++ b/schema.playground.kf
@@ -33,9 +33,9 @@ table credentials {
     human_id uuid notnull,
     credential_type text notnull,
     credential_level text,
-    credential_status text,
+    credential_status text, // idOS credential's status, not VC status (VC statuses are managed inside VC content and revocations mechanism)
     content text notnull,
-    encryption_public_key text notnull,
+    encryption_public_key text notnull, // public key of encryptor
     issuer text notnull,
     inserter text,
     #credentials_human_id index(human_id),
@@ -90,9 +90,33 @@ table external_access_grants {
     tx_hash text,
     block_hash text,
     height int,
-    status text,
+    // data_id in contract can be any data, but idOS expects uuid of a credential, so we need a status field to mark validity of the access grant
+    status text, // valid, invalid_by_reason, ...
     #external_ag_data_id_grantee index(data_id, ag_grantee),
     #external_ag_data_id_owner index(data_id, ag_owner)
+}
+
+// A human/user gives a grant to write data (create a credential, share the credential) on his behalf to some issuer
+table write_grants {
+    id uuid primary,
+    wg_owner text notnull, // human wallet/pk
+    wg_grantee text notnull, // issuer wallet/pk
+    wg_owner_human_id uuid notnull, // human's id, to be sure we will find the human if the owner's wallet will be deleted
+    #write_grants_human_id_grantee unique(wg_owner_human_id, wg_grantee)
+}
+
+// internal access grants can be granted if such permission is in write_grants
+table internal_access_grants {
+    id uuid primary,
+    ag_owner_human_id uuid notnull,
+    ag_grantee text notnull,
+    data_id uuid notnull,
+    locked_until int notnull default(0),
+    write_grant_id uuid, // This should be notnull, but we do set it to null in the FK.
+    foreign_key (write_grant_id) references write_grants(id) on_delete set null,
+    #iag_data_id index(data_id),
+    #iag_ag_grantee index(ag_grantee),
+    #iag_ag_owner_human_id index(ag_owner_human_id)
 }
 
 table configs {
@@ -311,10 +335,26 @@ procedure add_credential($id uuid, $credential_type text, $credential_level text
     );
 }
 
+procedure add_credential_by_write_grant(
+    $id uuid,
+    $human_id uuid,
+    $credential_type text,
+    $credential_level text,
+    $credential_status text,
+    $content text,
+    $encryption_public_key text,
+    $issuer text) public {
+
+    $wg_id := get_write_grant_id($human_id); // throw an error if no write_grant
+
+    INSERT INTO credentials (id, human_id, credential_type, credential_level, credential_status, content, encryption_public_key, issuer, inserter)
+    VALUES ($id, $human_id, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key, $issuer, $wg_id::TEXT);
+}
+
 // TODO: change to procedure
 @kgw(authn='true')
 action get_credentials() public view {
-	SELECT DISTINCT c.id, c.human_id, c.inserter, c.credential_type, c.credential_level, c.credential_status, sc.original_id AS original_id
+	SELECT DISTINCT c.id, c.human_id, c.inserter, c.credential_type, c.credential_level, c.credential_status, c.issuer, sc.original_id AS original_id
     FROM credentials AS c
     LEFT JOIN shared_credentials AS sc ON c.id = sc.duplicate_id
     INNER JOIN wallets ON c.human_id = wallets.human_id
@@ -346,6 +386,10 @@ action edit_credential($id, $credential_type, $credential_level, $credential_sta
 }
 
 procedure remove_credential($id uuid) public {
+    if !credential_belongs_to_caller($id) {
+        error('the credential does not belong to the caller');
+    }
+
     if has_locked_grants($id) {
         error('there are locked grants for this credential');
     }
@@ -354,6 +398,8 @@ procedure remove_credential($id uuid) public {
     AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
         OR (wallet_type = 'NEAR' AND public_key = @caller)
     );
+
+    DELETE FROM internal_access_grants WHERE data_id = $id;
 }
 
 // Do we need this procedure? Can share_credential_through_dag cover all cases?
@@ -367,23 +413,12 @@ procedure share_credential(
         $encryption_public_key text,
         $issuer text) public {
 
-    if !credential_belongs_to_human($original_credential_id) {
+    if !credential_belongs_to_caller($original_credential_id) {
         error('The original credential does not belong to the caller');
     }
 
     add_credential($id, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key, $issuer);
     INSERT INTO shared_credentials (original_id, duplicate_id) VALUES ($original_credential_id, $id);
-}
-
-procedure credential_belongs_to_human($id uuid) private returns (belongs bool) {
-    for $row in SELECT 1 from credentials
-        WHERE id = $id
-        AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-            OR (wallet_type = 'NEAR' AND public_key = @caller)) {
-        return true;
-    }
-
-    return false;
 }
 
 action share_credential_through_dag (
@@ -426,6 +461,54 @@ action share_credential_through_dag (
     INSERT INTO shared_credentials (original_id, duplicate_id) VALUES ($original_credential_id, $id);
 }
 
+procedure share_credential_by_write_grant(
+    $id uuid,
+    $human_id uuid,
+    $original_credential_id uuid,
+    $credential_type text,
+    $credential_level text,
+    $credential_status text,
+    $content text,
+    $encryption_public_key text,
+    $grantee text,
+    $locked_until int,
+    $issuer text) public {
+
+    if $locked_until < 0 {
+        error('locked_until must be positive integer timestamp or zero');
+    }
+
+    $wg_id := get_write_grant_id($human_id); // throw an error if no write_grant
+
+    if !credential_belongs_to_human($original_credential_id, $human_id) {
+        error('the original credential does not belong to the human');
+    }
+
+    if $wg_id::TEXT != get_credential_inserter($original_credential_id) {
+        error('you can share only original credentials you created');
+    }
+
+    $generated_uuid := uuid_generate_v5('31276fd4-105f-4ff7-9f64-644942c14b79'::uuid, format('%s-%s-%s', $grantee, $original_credential_id, $locked_until));
+    for $row in SELECT 1 FROM internal_access_grants WHERE id = $generated_uuid LIMIT 1 {
+        error('a grant with the same grantee, original_credential_id, and locked_until already exists');
+    }
+
+    INSERT INTO credentials (id, human_id, credential_type, credential_level, credential_status, content, encryption_public_key, issuer, inserter)
+        VALUES ($id, $human_id, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key, $issuer, $wg_id::TEXT);
+
+    INSERT INTO shared_credentials (original_id, duplicate_id) VALUES ($original_credential_id, $id);
+
+    INSERT INTO internal_access_grants (id, ag_owner_human_id, ag_grantee, data_id, locked_until, write_grant_id)
+        VALUES (
+            $generated_uuid,
+            $human_id,
+            $grantee,
+            $id,
+            $locked_until,
+            $wg_id
+        );
+}
+
 @kgw(authn='true')
 procedure credential_exist_as_inserter($id uuid) public view returns (credential_exist bool) {
     get_inserter();
@@ -452,27 +535,54 @@ procedure get_credential_shared ($id uuid) public view returns table (id uuid, h
         error('the credential does not exist');
     }
 
-    $granted bool := false;
-    $grant_valid bool := false;
+    $ext_ag_granted bool := false;
+    $ext_ag_grant_valid bool := false;
+    $int_ag_granted bool := false;
 
-    for $row in SELECT status FROM external_access_grants WHERE data_id = $id::TEXT AND ag_grantee = @caller COLLATE NOCASE {
-        $granted := true;
-        if $row.status == 'valid' {
-            $grant_valid := true;
+    for $ext_ag_row in SELECT status FROM external_access_grants WHERE data_id = $id::TEXT AND ag_grantee = @caller COLLATE NOCASE {
+        $ext_ag_granted := true;
+        if $ext_ag_row.status == 'valid' {
+            $ext_ag_grant_valid := true;
             break;
         }
     }
 
-    if !$granted {
-        error('the credential is not shared with the caller');
+    for $int_ag_row in SELECT 1 FROM internal_access_grants WHERE data_id = $id AND ag_grantee = @caller COLLATE NOCASE {
+        $int_ag_granted := true;
     }
 
-    if !$grant_valid {
-        error('the credential has no valid access grant; for more details, call list_ag_statuses');
+    // We only keep valid internal AGs. So, we only need to double-check the validity for external AGs.
+    if !$int_ag_granted {
+        if !$ext_ag_granted {
+            error('the credential is not shared with the caller');
+        }
+
+        if !$ext_ag_grant_valid {
+            error('the credential has no valid access grant; for more details, call list_external_ag_statuses');
+        }
     }
 
     return SELECT id, human_id, credential_type, credential_level, credential_status, content, encryption_public_key,
         issuer, inserter FROM credentials WHERE id = $id;
+}
+
+procedure credential_belongs_to_human($id uuid, $human_id uuid) private view returns (belongs bool) {
+    for $row in SELECT 1 from credentials WHERE id = $id AND human_id = $human_id LIMIT 1 {
+        return true;
+    }
+
+    return false;
+}
+
+procedure credential_belongs_to_caller($id uuid) private view returns (belongs bool) {
+    for $row in SELECT 1 from credentials
+        WHERE id = $id
+        AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = @caller)) {
+        return true;
+    }
+
+    return false;
 }
 
 procedure credential_exist($id uuid) private view returns (credential_exist bool) {
@@ -480,6 +590,14 @@ procedure credential_exist($id uuid) private view returns (credential_exist bool
         return true;
     }
     return false;
+}
+
+procedure get_credential_inserter($id uuid) private view returns (inserter text) {
+    for $row in SELECT inserter FROM credentials WHERE id = $id LIMIT 1 {
+        return $row.inserter;
+    }
+
+    error('credential not found');
 }
 
 
@@ -559,27 +677,15 @@ procedure share_attribute($id uuid, $original_attribute_id uuid, $attribute_key 
 }
 
 
-// ACCEESS GRANTS ACTIONS
+// EXTERNAL ACCESS GRANTS ACTIONS
 
 @kgw(authn='true')
-procedure list_ag_statuses($data_id text) public view returns table (ag_owner text, ag_grantee text, locked_until int, status text) {
+procedure list_external_ag_statuses($data_id text) public view returns table (ag_owner text, ag_grantee text, locked_until int, status text) {
     return
         SELECT ag_owner, ag_grantee, locked_until, status
         FROM external_access_grants
         WHERE data_id = $data_id
           AND ag_grantee = @caller;
-}
-
-@kgw(authn='true')
-procedure has_locked_grants($id uuid) public view returns (has bool) {
-    for $row in SELECT 1 FROM external_access_grants
-            WHERE data_id = $id::TEXT
-            AND ag_owner = @caller COLLATE NOCASE
-            AND status = 'valid'
-            AND locked_until >= @block_timestamp LIMIT 1 {
-        return true;
-    }
-    return false;
 }
 
 // This procedure is used in an oracle resolution to determine the status of a AG at the moment of adding it into idOS
@@ -607,6 +713,100 @@ procedure define_ag_status_as_owner($ag_owner text, $ag_grantee text, $data_id u
         }
 
     return 'invalid_ag_owner_does_not_match_original_credential_owner';
+}
+
+
+// WRITE GRANTS ACTIONS
+
+procedure add_write_grant($wg_grantee text) public {
+    INSERT INTO write_grants (id, wg_owner, wg_grantee, wg_owner_human_id) VALUES (
+        uuid_generate_v5('31276fd4-105f-4ff7-9f64-644942c14b79'::uuid, format('%s-%s', @caller, $wg_grantee)),
+        @caller,
+        $wg_grantee,
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = @caller)
+        )
+    );
+}
+
+procedure remove_write_grant($wg_grantee text) public {
+    DELETE FROM write_grants
+        WHERE wg_grantee = $wg_grantee COLLATE NOCASE
+        AND wg_owner_human_id = (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = @caller));
+}
+
+procedure get_write_grant_id($human_id uuid) private view returns (id uuid) {
+    for $row in SELECT id FROM write_grants WHERE wg_owner_human_id = $human_id AND wg_grantee = @caller COLLATE NOCASE LIMIT 1 {
+        return $row.id;
+    }
+
+    error('there is no write grant found');
+}
+
+
+// INTERNAL ACCESS GRANTS ACTIONS
+
+procedure revoke_internal_access_grant ($id uuid) public {
+    $iag_exist := false;
+    for $row in SELECT 1 FROM internal_access_grants WHERE id = $id
+        AND ag_owner_human_id = (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = @caller)) {
+        $iag_exist := true;
+    }
+
+    if !$iag_exist {
+        error('the internal access grant not found');
+    }
+
+    for $row2 in SELECT 1 FROM internal_access_grants WHERE id = $id
+        AND locked_until >= @block_timestamp
+        AND ag_owner_human_id = (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = @caller)) {
+        error('the grant is locked');
+    }
+
+    DELETE FROM internal_access_grants
+    WHERE id = $id
+    AND ag_owner_human_id = (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = @caller));
+}
+
+procedure get_internal_ag_owned () public view returns table (id uuid, ag_owner_human_id uuid,
+    ag_grantee text, data_id uuid, locked_until int, write_grant_id uuid) {
+    return SELECT id, ag_owner_human_id, ag_grantee, data_id, locked_until, write_grant_id FROM internal_access_grants
+        WHERE ag_owner_human_id = (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = @caller));
+}
+
+procedure get_internal_ag_granted () public view returns table (id uuid, ag_owner_human_id uuid,
+    ag_grantee text, data_id uuid, locked_until int) {
+    return SELECT id, ag_owner_human_id, ag_grantee, data_id, locked_until FROM internal_access_grants
+        WHERE ag_grantee =  @caller;
+}
+
+
+// BOTH GRANTS ACTIONS
+
+@kgw(authn='true')
+procedure has_locked_grants($id uuid) public view returns (has bool) {
+    for $ext_row in SELECT 1 FROM external_access_grants
+            WHERE data_id = $id::TEXT
+            AND ag_owner = @caller COLLATE NOCASE
+            AND status = 'valid'
+            AND locked_until >= @block_timestamp LIMIT 1 {
+        return true;
+    }
+
+    for $int_row in SELECT 1 FROM internal_access_grants
+            WHERE data_id = $id
+            AND ag_owner_human_id = (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+                OR (wallet_type = 'NEAR' AND public_key = @caller))
+            AND locked_until >= @block_timestamp LIMIT 1 {
+        return true;
+    }
+
+    return false;
 }
 
 
@@ -657,16 +857,61 @@ procedure insert_shared_attr_as_owner($original_id uuid, $duplicate_id uuid) own
     VALUES ($original_id, $duplicate_id);
 }
 
-// ACTIONS FOR IN-SCHEMA DATA MIGRATION
+// Some entities no need special actions because main actions do the same
+// inserters:  add_inserter_as_owner
+// delegates: add_delegate_as_owner
+// configs: upsert_config_as_owner
 
-procedure all_humans_as_owner() public view owner returns table (id uuid, current_public_key text, inserter text){
+procedure insert_external_ags_as_owner($id uuid, $ag_owner text, $ag_grantee text, $data_id text,
+    $locked_until int, $ag_chain text, $tx_hash text, $block_hash text, $height int, $status text
+    ) owner public {
+    INSERT INTO external_access_grants (id, ag_owner, ag_grantee, data_id, locked_until, ag_chain,
+        tx_hash, block_hash, height, status)
+    VALUES ($id, $ag_owner, $ag_grantee, $data_id, $locked_until, $ag_chain,
+        $tx_hash, $block_hash, $height, $status);
+}
+
+procedure insert_internal_ags_as_owner($id uuid, $ag_owner_human_id uuid, $ag_grantee text, $data_id uuid,
+    $locked_until int, $write_grant_id uuid) owner public {
+    INSERT INTO internal_access_grants (id, ag_owner_human_id, ag_grantee, data_id, locked_until, write_grant_id)
+    VALUES ($id, $ag_owner_human_id, $ag_grantee, $data_id, $locked_until, $write_grant_id);
+}
+
+procedure insert_write_grants_as_owner($id uuid, $wg_owner text, $wg_grantee text, $wg_owner_human_id uuid) owner public {
+    INSERT INTO write_grants (id, wg_owner, wg_grantee, wg_owner_human_id)
+    VALUES ($id, $wg_owner, $wg_grantee, $wg_owner_human_id);
+}
+
+
+// ACTIONS FOR IN-SCHEMA DATA MIGRATION (OWNER)
+
+procedure all_humans_as_owner() public view owner returns table (id uuid, current_public_key text, inserter text) {
     return SELECT id, current_public_key, inserter FROM humans;
 }
 
+foreign procedure get_all_humans() returns table(id uuid, current_public_key text, inserter text)
+
+procedure migrate_humans($dbid text) public owner {
+    for $row in SELECT id, current_public_key, inserter FROM get_all_humans[$dbid, 'all_humans_as_owner']() {
+        INSERT INTO humans (id, current_public_key, inserter) VALUES ($row.id, $row.current_public_key, $row.inserter);
+    }
+}
+
 procedure all_wallets_as_owner() public view owner returns table (id uuid, human_id uuid, address text, public_key text,
-    wallet_type text, message text, signature text, inserter text) {
+wallet_type text, message text, signature text, inserter text) {
     return SELECT id, human_id, address, public_key, wallet_type, message, signature, inserter FROM wallets;
 }
+
+foreign procedure get_all_wallets() returns table (id uuid, human_id uuid, address text, public_key text,
+wallet_type text, message text, signature text, inserter text)
+
+procedure migrate_wallets($dbid text) public owner {
+    for $row in SELECT id, human_id, address, public_key, wallet_type, message, signature, inserter FROM get_all_wallets[$dbid, 'all_wallets_as_owner']() {
+        INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature, inserter)
+            VALUES ($row.id, $row.human_id, $row.address, $row.public_key, $row.wallet_type, $row.message, $row.signature, $row.inserter);
+    }
+}
+
 
 procedure all_credentials_as_owner() public view owner returns table (id uuid, human_id uuid, credential_type text,
     credential_level text, credential_status text, content text, encryption_public_key text, issuer text, inserter text) {
@@ -674,32 +919,162 @@ procedure all_credentials_as_owner() public view owner returns table (id uuid, h
         issuer, inserter FROM credentials;
 }
 
+foreign procedure get_all_credentials() returns table (id uuid, human_id uuid, credential_type text,
+credential_level text, credential_status text, content text, encryption_public_key text, issuer text, inserter text)
+
+procedure migrate_credentials($dbid text) public owner {
+    for $row in SELECT id, human_id, credential_type, credential_level, credential_status, content,
+        encryption_public_key, issuer, inserter FROM get_all_credentials[$dbid, 'all_credentials_as_owner']() {
+        INSERT INTO credentials (id, human_id, credential_type, credential_level, credential_status, content,
+            encryption_public_key, issuer, inserter)
+        VALUES ($row.id, $row.human_id, $row.credential_type, $row.credential_level, $row.credential_status, $row.content,
+            $row.encryption_public_key, $row.issuer, $row.inserter);
+    }
+}
+
+
 procedure all_shared_credentials_as_owner() public view owner returns table (original_id uuid, duplicate_id uuid) {
     return SELECT original_id, duplicate_id FROM shared_credentials;
 }
+
+foreign procedure get_all_shared_credentials() returns table (original_id uuid, duplicate_id uuid)
+
+procedure migrate_shared_credentials($dbid text) public owner {
+    for $row in SELECT original_id, duplicate_id FROM get_all_shared_credentials[$dbid, 'all_shared_credentials_as_owner']() {
+        INSERT INTO shared_credentials (original_id, duplicate_id) VALUES ($row.original_id, $row.duplicate_id);
+    }
+}
+
 
 procedure all_human_attributes_as_owner() public view owner returns table (id uuid, human_id uuid, attribute_key text,
     value text, inserter text) {
     return SELECT id, human_id, attribute_key, value, inserter FROM human_attributes;
 }
 
+foreign procedure get_all_human_attributes() returns table (id uuid, human_id uuid, attribute_key text, value text, inserter text)
+
+procedure migrate_human_attributes($dbid text) public owner {
+    for $row in SELECT id, human_id, attribute_key, value, inserter FROM get_all_human_attributes[$dbid, 'all_human_attributes_as_owner']() {
+        INSERT INTO human_attributes (id, human_id, attribute_key, value, inserter)
+        VALUES ($row.id, $row.human_id, $row.attribute_key, $row.value, $row.inserter);
+    }
+}
+
+
 procedure all_shared_human_attrs_as_owner() public view owner returns table (original_id uuid, duplicate_id uuid) {
     return SELECT original_id, duplicate_id FROM shared_human_attributes;
 }
+
+foreign procedure get_all_shared_human_attrs() returns table (original_id uuid, duplicate_id uuid)
+
+procedure migrate_shared_human_attrs($dbid text) public owner {
+    for $row in SELECT original_id, duplicate_id FROM get_all_shared_human_attrs[$dbid, 'all_shared_human_attrs_as_owner']() {
+        INSERT INTO shared_human_attributes (original_id, duplicate_id) VALUES ($row.original_id, $row.duplicate_id);
+    }
+}
+
 
 procedure all_inserters_as_owner() public view owner returns table (id uuid, name text) {
     return SELECT id, name FROM inserters;
 }
 
+foreign procedure get_all_inserters() returns table (id uuid, name text)
+
+procedure migrate_inserters($dbid text) public owner {
+    for $row in SELECT id, name FROM get_all_inserters[$dbid, 'all_inserters_as_owner']() {
+        INSERT INTO inserters (id, name) VALUES ($row.id, $row.name);
+    }
+}
+
+
 procedure all_delegates_as_owner() public view owner returns table (address text, inserter_id uuid) {
     return SELECT address, inserter_id FROM delegates;
 }
 
-procedure all_grants_as_owner() public view owner returns table (id uuid, ag_owner text, ag_grantee text,
+foreign procedure get_all_delegates() returns table (address text, inserter_id uuid)
+
+procedure migrate_delegates($dbid text) public owner {
+    for $row in SELECT address, inserter_id FROM get_all_delegates[$dbid, 'all_delegates_as_owner']() {
+        INSERT INTO delegates (address, inserter_id) VALUES ($row.address, $row.inserter_id);
+    }
+}
+
+
+procedure all_external_grants_as_owner() public view owner returns table (id uuid, ag_owner text, ag_grantee text,
     data_id text, locked_until int, ag_chain text, tx_hash text, height int, block_hash text) {
     return SELECT id, ag_owner, ag_grantee, data_id, locked_until, ag_chain, tx_hash, height, block_hash FROM external_access_grants;
 }
 
+foreign procedure get_all_external_grants() returns table (id uuid, ag_owner text, ag_grantee text,
+    data_id text, locked_until int, ag_chain text, tx_hash text, height int, block_hash text)
+
+procedure migrate_external_grants($dbid text) public owner {
+    for $row in SELECT id, ag_owner, ag_grantee, data_id, locked_until, ag_chain, tx_hash, height, block_hash
+        FROM get_all_external_grants[$dbid, 'all_external_grants_as_owner']() {
+        INSERT INTO external_access_grants (id, ag_owner, ag_grantee, data_id, locked_until, ag_chain, tx_hash, height, block_hash)
+            VALUES ($row.id, $row.ag_owner, $row.ag_grantee, $row.data_id, $row.locked_until, $row.ag_chain,
+            $row.tx_hash, $row.height, $row.block_hash);
+    }
+}
+
+
+procedure all_internal_grants_as_owner() public view owner returns table (id uuid, ag_owner_human_id uuid, ag_grantee text,
+    data_id uuid, locked_until int, write_grant_id uuid) {
+    return SELECT id, ag_owner_human_id, ag_grantee, data_id, locked_until, write_grant_id FROM internal_access_grants;
+}
+
+foreign procedure get_all_internal_grants() returns table (id uuid, ag_owner_human_id uuid, ag_grantee text,
+    data_id uuid, locked_until int, write_grant_id uuid)
+
+procedure migrate_internal_grants($dbid text) public owner {
+    for $row in SELECT id, ag_owner_human_id, ag_grantee, data_id, locked_until, write_grant_id
+        FROM get_all_internal_grants[$dbid, 'all_internal_grants_as_owner']() {
+        INSERT INTO internal_access_grants (id, ag_owner_human_id, ag_grantee, data_id, locked_until, write_grant_id)
+            VALUES ($row.id, $row.ag_owner_human_id, $row.ag_grantee, $row.data_id, $row.locked_until, $row.write_grant_id);
+    }
+}
+
+
+procedure all_write_grants_as_owner() public view owner returns table (id uuid, wg_owner text, wg_grantee text,
+    wg_owner_human_id uuid) {
+    return SELECT id, wg_owner, wg_grantee, wg_owner_human_id FROM write_grants;
+}
+
+foreign procedure get_all_write_grants() returns table (id uuid, wg_owner text, wg_grantee text, wg_owner_human_id uuid)
+
+procedure migrate_write_grants($dbid text) public owner {
+    for $row in SELECT id, wg_owner, wg_grantee, wg_owner_human_id FROM get_all_write_grants[$dbid, 'all_write_grants_as_owner']() {
+        INSERT INTO write_grants (id, wg_owner, wg_grantee, wg_owner_human_id)
+            VALUES ($row.id, $row.wg_owner, $row.wg_grantee, $row.wg_owner_human_id);
+    }
+}
+
+
 procedure all_configs_as_owner() public view owner returns table (config_key text, value text) {
     return SELECT config_key, value FROM configs;
+}
+
+foreign procedure get_all_configs() returns table (config_key text, value text)
+
+procedure migrate_configs($dbid text) public owner {
+    for $row in SELECT config_key, value FROM get_all_configs[$dbid, 'all_configs_as_owner']() {
+        INSERT INTO configs (config_key, value)
+            VALUES ($row.config_key, $row.value);
+    }
+}
+
+// The sequence of inserting of tables is important
+procedure migrate_all_data($old_dbid text) public owner {
+    migrate_humans($old_dbid);
+    migrate_wallets($old_dbid);
+    migrate_credentials($old_dbid);
+    migrate_shared_credentials($old_dbid);
+    migrate_human_attributes($old_dbid);
+    migrate_shared_human_attrs($old_dbid);
+    migrate_inserters($old_dbid);
+    migrate_delegates($old_dbid);
+    migrate_external_grants($old_dbid);
+    migrate_write_grants($old_dbid); // WGs must be inserted before internal AGs
+    migrate_internal_grants($old_dbid);
+    migrate_configs($old_dbid);
 }

--- a/schema.production.kf
+++ b/schema.production.kf
@@ -354,7 +354,7 @@ procedure add_credential_by_write_grant(
 // TODO: change to procedure
 @kgw(authn='true')
 action get_credentials() public view {
-	SELECT DISTINCT c.id, c.human_id, c.inserter, c.credential_type, c.credential_level, c.credential_status, c.issuer, sc.original_id AS original_id
+    SELECT DISTINCT c.id, c.human_id, c.inserter, c.credential_type, c.credential_level, c.credential_status, c.issuer, sc.original_id AS original_id
     FROM credentials AS c
     LEFT JOIN shared_credentials AS sc ON c.id = sc.duplicate_id
     INNER JOIN wallets ON c.human_id = wallets.human_id
@@ -623,7 +623,7 @@ procedure add_attribute($id uuid, $attribute_key text, $value text) public {
 // TODO: change to procedure
 @kgw(authn='true')
 action get_attributes() public view {
-	SELECT DISTINCT ha.id, ha.human_id, ha.attribute_key, ha.value, sha.original_id AS original_id
+    SELECT DISTINCT ha.id, ha.human_id, ha.attribute_key, ha.value, sha.original_id AS original_id
     FROM human_attributes AS ha
     LEFT JOIN shared_human_attributes AS sha ON ha.id = sha.duplicate_id
     INNER JOIN wallets ON ha.human_id = wallets.human_id

--- a/schema.production.kf
+++ b/schema.production.kf
@@ -2,25 +2,8 @@ database idos;
 
 // EXTENSION INITIALIZATION
 
-use idos {
-    registry_address: '0xA5Ac9B9703Bd661cd2aC05B41FE57d1A5DD332AA',
-    chain: 'eth'
-} as idos_eth;
+use idos as idos;
 
-use idos {
-    registry_address: 'idos-dev-1.near',
-    chain: 'near'
-} as idos_near;
-
-use idos {
-    registry_address: '0x350829c8FCb3DF16EeaE9ADDa2565090348426f9',
-    chain: 'arbitrum'
-} as idos_arbitrum;
-
-use idos {
-    registry_address: '0xeed5537b68baD728A3Bb433d8e06ebab81ac0EAB',
-    chain: 'etherlink'
-} as idos_etherlink;
 
 // TABLES
 
@@ -63,6 +46,7 @@ table shared_credentials {
     original_id uuid notnull,
     duplicate_id uuid notnull,
     #primary_key primary(original_id, duplicate_id),
+    #shared_credentials_duplicate_id index(duplicate_id),
     foreign_key (original_id) references credentials(id) on_delete cascade,
     foreign_key (duplicate_id) references credentials(id) on_delete cascade
 }
@@ -96,8 +80,47 @@ table delegates {
     foreign_key (inserter_id) references inserters(id) on_delete cascade
 }
 
+table access_grants {
+    id uuid primary,
+    ag_owner text notnull,
+    ag_grantee text notnull,
+    data_id text notnull,
+    locked_until int,
+    ag_chain text notnull,
+    tx_hash text,
+    block_hash text,
+    height int,
+    status text,
+    #access_grants_data_id_grantee index(data_id, ag_grantee),
+    #access_grants_data_id_owner index(data_id, ag_owner)
+}
 
-// inserter AND DELEGATE ACTIONS
+table configs {
+    config_key text primary,
+    value text
+}
+
+
+// CONFIG ACTIONS
+
+procedure upsert_config_as_owner($config_key text, $value text) public owner {
+    INSERT INTO configs (config_key, value) VALUES ($config_key, $value)
+        ON CONFLICT(config_key) DO UPDATE
+            SET value = $value;
+}
+
+procedure delete_config_as_owner($config_key text) public owner {
+    DELETE FROM configs WHERE config_key = $config_key;
+}
+
+procedure get_config_as_owner($config_key text) public view owner returns (value text) {
+    for $row in SELECT config_key, value FROM configs WHERE config_key = $config_key {
+        return $row.value;
+    }
+}
+
+
+// INSERTER AND DELEGATE ACTIONS
 
 procedure add_inserter_as_owner($id uuid, $name text) owner public {
     INSERT INTO inserters (id, name) VALUES ($id, $name);
@@ -150,18 +173,17 @@ procedure delete_human_as_owner($id uuid) public owner {
 // DEPRECATED
 @kgw(authn='true')
 action get_wallet_human_id() public view {
-    $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT DISTINCT human_id FROM wallets
     WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted);
+        OR (wallet_type = 'NEAR' AND public_key = @caller);
 }
 
+// TODO: change to procedure
 @kgw(authn='true')
 action get_human() public view {
-    $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT id, current_public_key FROM humans
     WHERE id = (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted));
+        OR (wallet_type = 'NEAR' AND public_key = @caller));
 }
 
 @kgw(authn='true')
@@ -175,11 +197,12 @@ procedure get_human_as_inserter($id uuid) public view returns (id uuid, current_
 
 // WALLET ACTIONS
 
+// TODO: change to procedure
 action upsert_wallet_as_inserter($id, $human_id, $address, $public_key, $wallet_type, $message, $signature) public {
     SELECT CASE WHEN $wallet_type = 'NEAR' AND $public_key::TEXT IS NULL THEN ERROR('NEAR wallets require a public_key to be given.') END;
 
-    $valid_near_public_key = idos_near.is_valid_public_key($public_key);
-    SELECT CASE WHEN $wallet_type = 'NEAR' AND $valid_near_public_key != 1 THEN ERROR('Invalid or unsupported public key.') END;
+    $valid_public_key = idos.is_valid_public_key($public_key, $wallet_type);
+    SELECT CASE WHEN $wallet_type = 'NEAR' AND $valid_public_key != 1 THEN ERROR('Invalid or unsupported public key.') END;
 
     INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature, inserter)
     VALUES ($id, $human_id, $address, $public_key, $wallet_type, $message, $signature, get_inserter())
@@ -192,20 +215,20 @@ procedure delete_wallet_as_owner($id uuid) public owner {
     DELETE FROM wallets WHERE id=$id;
 }
 
+// Do we need to ask user/sdk to provide id? It is possible now to generate the `id` in the procedure in consensus way
 action add_wallet($id, $address, $public_key, $message, $signature) public {
-    $converted = idos_near.implicit_address_to_public_key(@caller);
-    $wallet_type = idos_near.determine_wallet_type($address);
+    $wallet_type = idos.determine_wallet_type($address);
 
     SELECT CASE WHEN $wallet_type = 'NEAR' AND $public_key::TEXT IS NULL THEN ERROR('NEAR wallets require a public_key to be given.') END;
 
-    $valid_near_public_key = idos_near.is_valid_public_key($public_key);
-    SELECT CASE WHEN $wallet_type = 'NEAR' AND $valid_near_public_key != 1 THEN ERROR('Invalid or unsupported public key.') END;
+    $valid_public_key = idos.is_valid_public_key($public_key, $wallet_type);
+    SELECT CASE WHEN $wallet_type = 'NEAR' AND $valid_public_key != 1 THEN ERROR('Invalid or unsupported public key.') END;
 
     INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature)
     VALUES (
         $id,
         (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-            OR (wallet_type = 'NEAR' AND public_key = $converted)
+            OR (wallet_type = 'NEAR' AND public_key = @caller)
         ),
         $address,
         CASE
@@ -218,31 +241,34 @@ action add_wallet($id, $address, $public_key, $message, $signature) public {
     );
 }
 
+// TODO: change to procedure
 @kgw(authn='true')
 action get_wallets() public view {
-    $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT DISTINCT w1.*
     FROM wallets AS w1
     INNER JOIN wallets AS w2 ON w1.human_id = w2.human_id
     WHERE (
         w2.wallet_type = 'EVM' AND w2.address = @caller COLLATE NOCASE
     ) OR (
-        w2.wallet_type = 'NEAR' AND w2.public_key = $converted
+        w2.wallet_type = 'NEAR' AND w2.public_key = @caller
     );
 }
 
-action remove_wallet($id) public {
-    $converted = idos_near.implicit_address_to_public_key(@caller);
-    SELECT CASE
-    WHEN EXISTS (SELECT count(id) FROM wallets
-        WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE) OR (wallet_type = 'NEAR' AND public_key = $converted)
-        GROUP BY address HAVING count(id) = 1)
-    THEN ERROR('A human needs to have at least one wallet. We can not delete the last wallet.')
-    END;
+procedure remove_wallet($id uuid) public {
+    for $row in SELECT id FROM wallets
+        WHERE id = $id
+        AND ((wallet_type = 'EVM' AND address=@caller COLLATE NOCASE) OR (wallet_type = 'NEAR' AND public_key = @caller))
+        AND EXISTS (
+            SELECT count(id) FROM wallets
+                WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE) OR (wallet_type = 'NEAR' AND public_key = @caller)
+                GROUP BY human_id HAVING count(id) = 1
+        ) {
+        error('You can not delete a wallet you are connected with. To delete this wallet you have to connect other wallet.');
+    }
 
     DELETE FROM wallets
     WHERE id=$id AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted)
+        OR (wallet_type = 'NEAR' AND public_key = @caller)
     );
 }
 
@@ -264,16 +290,17 @@ procedure upsert_credential_as_inserter(
     ON CONFLICT(id) DO UPDATE
     SET credential_status=$credential_status, content=$content, encryption_public_key=$encryption_public_key, issuer=$issuer, inserter=$inserter;
 
+    // Do we still need this return?
     return true; // dummy return value is needed when the procedure is called from an action like `SELECT procedure_call()`;
 }
 
-action add_credential($id, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key, $issuer) public {
-    $converted = idos_near.implicit_address_to_public_key(@caller);
+procedure add_credential($id uuid, $credential_type text, $credential_level text, $credential_status text, $content text,
+    $encryption_public_key text, $issuer text) public {
     INSERT INTO credentials (id, human_id, credential_type, credential_level, credential_status, content, encryption_public_key, issuer)
     VALUES (
         $id,
         (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-            OR (wallet_type = 'NEAR' AND public_key = $converted)
+            OR (wallet_type = 'NEAR' AND public_key = @caller)
         ),
         $credential_type,
         $credential_level,
@@ -284,9 +311,9 @@ action add_credential($id, $credential_type, $credential_level, $credential_stat
     );
 }
 
+// TODO: change to procedure
 @kgw(authn='true')
 action get_credentials() public view {
-    $converted = idos_near.implicit_address_to_public_key(@caller);
 	SELECT DISTINCT c.id, c.human_id, c.inserter, c.credential_type, c.credential_level, c.credential_status, sc.original_id AS original_id
     FROM credentials AS c
     LEFT JOIN shared_credentials AS sc ON c.id = sc.duplicate_id
@@ -294,19 +321,19 @@ action get_credentials() public view {
     WHERE (
         wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE
     ) OR (
-        wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted
+        wallets.wallet_type = 'NEAR' AND wallets.public_key = @caller
     );
 }
 
+// TODO: change to procedure
 action edit_credential($id, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key, $issuer) public {
-    $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT CASE
         WHEN EXISTS (
             SELECT 1 from credentials AS c
                 INNER JOIN shared_credentials AS sc on c.id = sc.duplicate_id
                 WHERE c.id = $id
                 AND c.human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-                    OR (wallet_type = 'NEAR' AND public_key = $converted))
+                    OR (wallet_type = 'NEAR' AND public_key = @caller))
         ) THEN ERROR('Can not edit shared credential') END;
 
     UPDATE credentials
@@ -314,47 +341,49 @@ action edit_credential($id, $credential_type, $credential_level, $credential_sta
         content=$content, encryption_public_key=$encryption_public_key, issuer=$issuer
     WHERE id=$id
     AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted)
+        OR (wallet_type = 'NEAR' AND public_key = @caller)
     );
 }
 
-action remove_credential($id) public {
-    $has_locked_grants_eth = idos_eth.has_locked_grants(@caller, $id);
-    $has_locked_grants_near = idos_near.has_locked_grants(@caller, $id);
-    $has_locked_grants_arbitrum = idos_arbitrum.has_locked_grants(@caller, $id);
-    $has_locked_grants_etherlink = idos_etherlink.has_locked_grants(@caller, $id);
-    SELECT CASE
-        WHEN $has_locked_grants_eth = 1 OR $has_locked_grants_near = 1 OR $has_locked_grants_arbitrum = 1 OR $has_locked_grants_etherlink = 1
-        THEN ERROR('there are locked grants for this credential') END;
-
-    $converted = idos_near.implicit_address_to_public_key(@caller);
+procedure remove_credential($id uuid) public {
+    if has_locked_grants($id) {
+        error('there are locked grants for this credential');
+    }
     DELETE FROM credentials
     WHERE id=$id
     AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted)
+        OR (wallet_type = 'NEAR' AND public_key = @caller)
     );
 }
 
-action share_credential(
-        $id,
-        $original_credential_id,
-        $credential_type,
-        $credential_level,
-        $credential_status,
-        $content,
-        $encryption_public_key,
-        $issuer) public {
-    $converted = idos_near.implicit_address_to_public_key(@caller);
-    SELECT CASE
-    WHEN NOT EXISTS (
-        SELECT 1 from credentials
-            WHERE id = $original_credential_id
-            AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-                OR (wallet_type = 'NEAR' AND public_key = $converted))
-    ) THEN ERROR('The original credential does not belong to the caller') END;
+// Do we need this procedure? Can share_credential_through_dag cover all cases?
+procedure share_credential(
+        $id uuid,
+        $original_credential_id uuid,
+        $credential_type text,
+        $credential_level text,
+        $credential_status text,
+        $content text,
+        $encryption_public_key text,
+        $issuer text) public {
+
+    if !credential_belongs_to_human($original_credential_id) {
+        error('The original credential does not belong to the caller');
+    }
 
     add_credential($id, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key, $issuer);
     INSERT INTO shared_credentials (original_id, duplicate_id) VALUES ($original_credential_id, $id);
+}
+
+procedure credential_belongs_to_human($id uuid) private returns (belongs bool) {
+    for $row in SELECT 1 from credentials
+        WHERE id = $id
+        AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = @caller)) {
+        return true;
+    }
+
+    return false;
 }
 
 action share_credential_through_dag (
@@ -378,7 +407,7 @@ action share_credential_through_dag (
             AND human_id = $human_id
     ) THEN ERROR('The original credential does not belong to the human') END;
 
-    $owner_verified = idos_eth.verify_owner($dag_owner, $dag_grantee, $id, $dag_locked_until, $dag_signature);
+    $owner_verified = idos.verify_owner($dag_owner, $dag_grantee, $id, $dag_locked_until, $dag_signature);
     SELECT CASE
         WHEN $owner_verified != 1 THEN ERROR('the signature is invalid')
     END;
@@ -400,39 +429,57 @@ action share_credential_through_dag (
 @kgw(authn='true')
 procedure credential_exist_as_inserter($id uuid) public view returns (credential_exist bool) {
     get_inserter();
-    for $row in SELECT 1 FROM credentials WHERE id = $id {
-        return true;
-    }
-    return false;
+    return credential_exist($id);
 }
 
+// TODO: change to procedure
 @kgw(authn='true')
 action get_credential_owned ($id) public view {
-    $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT DISTINCT credentials.*
     FROM credentials
     INNER JOIN wallets ON credentials.human_id = wallets.human_id
     WHERE credentials.id = $id
     AND (
         (wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE)
-            OR (wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted)
+            OR (wallets.wallet_type = 'NEAR' AND wallets.public_key = @caller)
     );
 }
 
 @kgw(authn='true')
-action get_credential_shared ($id) public view {
-    $has_grant_on_eth = idos_eth.has_grants(@caller, $id);
-    $has_grant_on_near = idos_near.has_grants(@caller, $id);
-    $has_grant_on_arbitrum = idos_arbitrum.has_grants(@caller, $id);
-    $has_grant_on_etherlink = idos_etherlink.has_grants(@caller, $id);
+procedure get_credential_shared ($id uuid) public view returns table (id uuid, human_id uuid, credential_type text,
+    credential_level text, credential_status text, content text, encryption_public_key text, issuer text, inserter text) {
+    if !credential_exist($id) {
+        error('the credential does not exist');
+    }
 
-    SELECT CASE
-        WHEN $has_grant_on_eth != 1 AND $has_grant_on_near != 1 AND $has_grant_on_arbitrum != 1 AND $has_grant_on_etherlink != 1
-        THEN ERROR('caller does not have access') END;
+    $granted bool := false;
+    $grant_valid bool := false;
 
-    SELECT *
-    FROM credentials
-    WHERE id = $id;
+    for $row in SELECT status FROM access_grants WHERE data_id = $id::TEXT AND ag_grantee = @caller COLLATE NOCASE {
+        $granted := true;
+        if $row.status == 'valid' {
+            $grant_valid := true;
+            break;
+        }
+    }
+
+    if !$granted {
+        error('the credential is not shared with the caller');
+    }
+
+    if !$grant_valid {
+        error('the credential has no valid access grant; for more details, call list_ag_statuses');
+    }
+
+    return SELECT id, human_id, credential_type, credential_level, credential_status, content, encryption_public_key,
+        issuer, inserter FROM credentials WHERE id = $id;
+}
+
+procedure credential_exist($id uuid) private view returns (credential_exist bool) {
+    for $row in SELECT 1 FROM credentials WHERE id = $id {
+        return true;
+    }
+    return false;
 }
 
 
@@ -443,22 +490,21 @@ procedure add_attribute_as_inserter($id uuid, $human_id uuid, $attribute_key tex
     VALUES ($id, $human_id, $attribute_key, $value, get_inserter());
 }
 
-action add_attribute($id, $attribute_key, $value) public {
-    $converted = idos_near.implicit_address_to_public_key(@caller);
+procedure add_attribute($id uuid, $attribute_key text, $value text) public {
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
     VALUES (
         $id,
         (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-            OR (wallet_type = 'NEAR' AND public_key = $converted)
+            OR (wallet_type = 'NEAR' AND public_key = @caller)
         ),
         $attribute_key,
         $value
     );
 }
 
+// TODO: change to procedure
 @kgw(authn='true')
 action get_attributes() public view {
-    $converted = idos_near.implicit_address_to_public_key(@caller);
 	SELECT DISTINCT ha.id, ha.human_id, ha.attribute_key, ha.value, sha.original_id AS original_id
     FROM human_attributes AS ha
     LEFT JOIN shared_human_attributes AS sha ON ha.id = sha.duplicate_id
@@ -466,45 +512,43 @@ action get_attributes() public view {
     WHERE (
         wallets.wallet_type = 'EVM' AND wallets.address = @caller COLLATE NOCASE
     ) OR (
-        wallets.wallet_type = 'NEAR' AND wallets.public_key = $converted
+        wallets.wallet_type = 'NEAR' AND wallets.public_key = @caller
     );
 }
 
+// TODO: change to procedure
 action edit_attribute($id, $attribute_key, $value) public {
-    $converted = idos_near.implicit_address_to_public_key(@caller);
     SELECT CASE
         WHEN EXISTS (
             SELECT 1 from human_attributes AS ha
                 INNER JOIN shared_human_attributes AS sha on ha.id = sha.duplicate_id
                 WHERE ha.id = $id
                 AND ha.human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-                    OR (wallet_type = 'NEAR' AND public_key = $converted))
+                    OR (wallet_type = 'NEAR' AND public_key = @caller))
         ) THEN ERROR('Can not edit shared attribute') END;
 
     UPDATE human_attributes
     SET attribute_key=$attribute_key, value=$value
     WHERE id=$id
     AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted)
+        OR (wallet_type = 'NEAR' AND public_key = @caller)
     );
 }
 
-action remove_attribute($id) public {
-    $converted = idos_near.implicit_address_to_public_key(@caller);
+procedure remove_attribute($id uuid) public {
     DELETE FROM human_attributes
     WHERE id=$id
     AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-        OR (wallet_type = 'NEAR' AND public_key = $converted)
+        OR (wallet_type = 'NEAR' AND public_key = @caller)
     );
 }
 
-action share_attribute($id, $original_attribute_id, $attribute_key, $value) public {
-    $converted = idos_near.implicit_address_to_public_key(@caller);
+procedure share_attribute($id uuid, $original_attribute_id uuid, $attribute_key text, $value text) public {
     INSERT INTO human_attributes (id, human_id, attribute_key, value)
     VALUES (
         $id,
         (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-            OR (wallet_type = 'NEAR' AND public_key = $converted)
+            OR (wallet_type = 'NEAR' AND public_key = @caller)
         ),
         $attribute_key,
         $value
@@ -515,9 +559,61 @@ action share_attribute($id, $original_attribute_id, $attribute_key, $value) publ
 }
 
 
+// ACCEESS GRANTS ACTIONS
+
+@kgw(authn='true')
+procedure list_ag_statuses($data_id text) public view returns table (ag_owner text, ag_grantee text, locked_until int, status text) {
+    return
+        SELECT ag_owner, ag_grantee, locked_until, status
+        FROM access_grants
+        WHERE data_id = $data_id
+          AND ag_grantee = @caller;
+}
+
+@kgw(authn='true')
+procedure has_locked_grants($id uuid) public view returns (has bool) {
+    for $row in SELECT 1 FROM access_grants
+            WHERE data_id = $id::TEXT
+            AND ag_owner = @caller COLLATE NOCASE
+            AND status = 'valid'
+            AND locked_until >= @block_timestamp LIMIT 1 {
+        return true;
+    }
+    return false;
+}
+
+// This procedure is used in an oracle resolution to determine the status of a AG at the moment of adding it into idOS
+// It needs to be done at this moment because of later defining data can change (original credential deleted, owner wallet or profile removed etc.)
+procedure define_ag_status_as_owner($ag_owner text, $ag_grantee text, $data_id uuid) public view owner returns (status text) {
+    if !credential_exist($data_id) {
+        return 'invalid_data_id_not_found';
+    }
+
+    $data_id_is_duplicate := false;
+    for $row in SELECT 1 FROM shared_credentials WHERE duplicate_id = $data_id LIMIT 1 {
+        $data_id_is_duplicate := true;
+    }
+    if !$data_id_is_duplicate {
+        return 'invalid_data_id_is_not_a_duplicate';
+    }
+
+    for $row2 in SELECT 1 FROM wallets
+        INNER JOIN credentials ON credentials.human_id = wallets.human_id
+        WHERE credentials.id = $data_id
+        AND ((wallets.address = $ag_owner COLLATE NOCASE AND wallets.wallet_type = 'EVM')
+            OR (wallets.public_key = $ag_owner COLLATE NOCASE AND wallets.wallet_type = 'NEAR'))
+        LIMIT 1 {
+            return 'valid';
+        }
+
+    return 'invalid_ag_owner_does_not_match_original_credential_owner';
+}
+
+
 // OTHER ACTIONS
 
 // Should we improve it to work with near wallets too?
+// TODO: change to procedure
 action has_profile($address) public view {
     SELECT EXISTS (
         SELECT 1 FROM wallets WHERE address=$address COLLATE NOCASE
@@ -525,7 +621,7 @@ action has_profile($address) public view {
 }
 
 
-// OWNER ACTIONS FOR MIGRATIONS
+// OWNER ACTIONS FOR MANUAL MIGRATIONS
 
 procedure insert_human_as_owner($id uuid, $current_public_key text, $inserter text) owner public {
     INSERT INTO humans (id, current_public_key, inserter)
@@ -533,13 +629,13 @@ procedure insert_human_as_owner($id uuid, $current_public_key text, $inserter te
 }
 
 procedure insert_wallet_as_owner($id uuid, $human_id uuid, $address text, $public_key text, $wallet_type text,
-$message text, $signature text, $inserter text) owner public {
+    $message text, $signature text, $inserter text) owner public {
     INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature, inserter)
     VALUES ($id, $human_id, $address, $public_key, $wallet_type, $message, $signature, $inserter);
 }
 
 procedure insert_credential_as_owner($id uuid, $human_id uuid, $credential_type text, $credential_level text,
-$credential_status text, $content text, $encryption_public_key text, $issuer text, $inserter text) owner public {
+    $credential_status text, $content text, $encryption_public_key text, $issuer text, $inserter text) owner public {
     INSERT INTO credentials (id, human_id, credential_type, credential_level, credential_status, content,
     encryption_public_key, issuer, inserter)
     VALUES ($id, $human_id, $credential_type, $credential_level, $credential_status, $content,
@@ -559,4 +655,51 @@ procedure insert_human_attribute_as_owner($id uuid, $human_id uuid, $attribute_k
 procedure insert_shared_attr_as_owner($original_id uuid, $duplicate_id uuid) owner public {
     INSERT INTO shared_human_attributes (original_id, duplicate_id)
     VALUES ($original_id, $duplicate_id);
+}
+
+// ACTIONS FOR IN-SCHEMA DATA MIGRATION
+
+procedure all_humans_as_owner() public view owner returns table (id uuid, current_public_key text, inserter text){
+    return SELECT id, current_public_key, inserter FROM humans;
+}
+
+procedure all_wallets_as_owner() public view owner returns table (id uuid, human_id uuid, address text, public_key text,
+    wallet_type text, message text, signature text, inserter text) {
+    return SELECT id, human_id, address, public_key, wallet_type, message, signature, inserter FROM wallets;
+}
+
+procedure all_credentials_as_owner() public view owner returns table (id uuid, human_id uuid, credential_type text,
+    credential_level text, credential_status text, content text, encryption_public_key text, issuer text, inserter text) {
+    return SELECT id, human_id, credential_type, credential_level, credential_status, content, encryption_public_key,
+        issuer, inserter FROM credentials;
+}
+
+procedure all_shared_credentials_as_owner() public view owner returns table (original_id uuid, duplicate_id uuid) {
+    return SELECT original_id, duplicate_id FROM shared_credentials;
+}
+
+procedure all_human_attributes_as_owner() public view owner returns table (id uuid, human_id uuid, attribute_key text,
+    value text, inserter text) {
+    return SELECT id, human_id, attribute_key, value, inserter FROM human_attributes;
+}
+
+procedure all_shared_human_attrs_as_owner() public view owner returns table (original_id uuid, duplicate_id uuid) {
+    return SELECT original_id, duplicate_id FROM shared_human_attributes;
+}
+
+procedure all_inserters_as_owner() public view owner returns table (id uuid, name text) {
+    return SELECT id, name FROM inserters;
+}
+
+procedure all_delegates_as_owner() public view owner returns table (address text, inserter_id uuid) {
+    return SELECT address, inserter_id FROM delegates;
+}
+
+procedure all_grants_as_owner() public view owner returns table (id uuid, ag_owner text, ag_grantee text,
+    data_id text, locked_until int, ag_chain text, tx_hash text, height int, block_hash text) {
+    return SELECT id, ag_owner, ag_grantee, data_id, locked_until, ag_chain, tx_hash, height, block_hash FROM access_grants;
+}
+
+procedure all_configs_as_owner () public view owner returns table (config_key text, value text) {
+    return SELECT config_key, value FROM configs;
 }

--- a/schema.production.kf
+++ b/schema.production.kf
@@ -33,9 +33,9 @@ table credentials {
     human_id uuid notnull,
     credential_type text notnull,
     credential_level text,
-    credential_status text,
+    credential_status text, // idOS credential's status, not VC status (VC statuses are managed inside VC content and revocations mechanism)
     content text notnull,
-    encryption_public_key text notnull,
+    encryption_public_key text notnull, // public key of encryptor
     issuer text notnull,
     inserter text,
     #credentials_human_id index(human_id),
@@ -90,9 +90,33 @@ table external_access_grants {
     tx_hash text,
     block_hash text,
     height int,
-    status text,
+    // data_id in contract can be any data, but idOS expects uuid of a credential, so we need a status field to mark validity of the access grant
+    status text, // valid, invalid_by_reason, ...
     #external_ag_data_id_grantee index(data_id, ag_grantee),
     #external_ag_data_id_owner index(data_id, ag_owner)
+}
+
+// A human/user gives a grant to write data (create a credential, share the credential) on his behalf to some issuer
+table write_grants {
+    id uuid primary,
+    wg_owner text notnull, // human wallet/pk
+    wg_grantee text notnull, // issuer wallet/pk
+    wg_owner_human_id uuid notnull, // human's id, to be sure we will find the human if the owner's wallet will be deleted
+    #write_grants_human_id_grantee unique(wg_owner_human_id, wg_grantee)
+}
+
+// internal access grants can be granted if such permission is in write_grants
+table internal_access_grants {
+    id uuid primary,
+    ag_owner_human_id uuid notnull,
+    ag_grantee text notnull,
+    data_id uuid notnull,
+    locked_until int notnull default(0),
+    write_grant_id uuid, // This should be notnull, but we do set it to null in the FK.
+    foreign_key (write_grant_id) references write_grants(id) on_delete set null,
+    #iag_data_id index(data_id),
+    #iag_ag_grantee index(ag_grantee),
+    #iag_ag_owner_human_id index(ag_owner_human_id)
 }
 
 table configs {
@@ -311,10 +335,26 @@ procedure add_credential($id uuid, $credential_type text, $credential_level text
     );
 }
 
+procedure add_credential_by_write_grant(
+    $id uuid,
+    $human_id uuid,
+    $credential_type text,
+    $credential_level text,
+    $credential_status text,
+    $content text,
+    $encryption_public_key text,
+    $issuer text) public {
+
+    $wg_id := get_write_grant_id($human_id); // throw an error if no write_grant
+
+    INSERT INTO credentials (id, human_id, credential_type, credential_level, credential_status, content, encryption_public_key, issuer, inserter)
+    VALUES ($id, $human_id, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key, $issuer, $wg_id::TEXT);
+}
+
 // TODO: change to procedure
 @kgw(authn='true')
 action get_credentials() public view {
-	SELECT DISTINCT c.id, c.human_id, c.inserter, c.credential_type, c.credential_level, c.credential_status, sc.original_id AS original_id
+	SELECT DISTINCT c.id, c.human_id, c.inserter, c.credential_type, c.credential_level, c.credential_status, c.issuer, sc.original_id AS original_id
     FROM credentials AS c
     LEFT JOIN shared_credentials AS sc ON c.id = sc.duplicate_id
     INNER JOIN wallets ON c.human_id = wallets.human_id
@@ -346,6 +386,10 @@ action edit_credential($id, $credential_type, $credential_level, $credential_sta
 }
 
 procedure remove_credential($id uuid) public {
+    if !credential_belongs_to_caller($id) {
+        error('the credential does not belong to the caller');
+    }
+
     if has_locked_grants($id) {
         error('there are locked grants for this credential');
     }
@@ -354,6 +398,8 @@ procedure remove_credential($id uuid) public {
     AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
         OR (wallet_type = 'NEAR' AND public_key = @caller)
     );
+
+    DELETE FROM internal_access_grants WHERE data_id = $id;
 }
 
 // Do we need this procedure? Can share_credential_through_dag cover all cases?
@@ -367,23 +413,12 @@ procedure share_credential(
         $encryption_public_key text,
         $issuer text) public {
 
-    if !credential_belongs_to_human($original_credential_id) {
+    if !credential_belongs_to_caller($original_credential_id) {
         error('The original credential does not belong to the caller');
     }
 
     add_credential($id, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key, $issuer);
     INSERT INTO shared_credentials (original_id, duplicate_id) VALUES ($original_credential_id, $id);
-}
-
-procedure credential_belongs_to_human($id uuid) private returns (belongs bool) {
-    for $row in SELECT 1 from credentials
-        WHERE id = $id
-        AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-            OR (wallet_type = 'NEAR' AND public_key = @caller)) {
-        return true;
-    }
-
-    return false;
 }
 
 action share_credential_through_dag (
@@ -426,6 +461,54 @@ action share_credential_through_dag (
     INSERT INTO shared_credentials (original_id, duplicate_id) VALUES ($original_credential_id, $id);
 }
 
+procedure share_credential_by_write_grant(
+    $id uuid,
+    $human_id uuid,
+    $original_credential_id uuid,
+    $credential_type text,
+    $credential_level text,
+    $credential_status text,
+    $content text,
+    $encryption_public_key text,
+    $grantee text,
+    $locked_until int,
+    $issuer text) public {
+
+    if $locked_until < 0 {
+        error('locked_until must be positive integer timestamp or zero');
+    }
+
+    $wg_id := get_write_grant_id($human_id); // throw an error if no write_grant
+
+    if !credential_belongs_to_human($original_credential_id, $human_id) {
+        error('the original credential does not belong to the human');
+    }
+
+    if $wg_id::TEXT != get_credential_inserter($original_credential_id) {
+        error('you can share only original credentials you created');
+    }
+
+    $generated_uuid := uuid_generate_v5('31276fd4-105f-4ff7-9f64-644942c14b79'::uuid, format('%s-%s-%s', $grantee, $original_credential_id, $locked_until));
+    for $row in SELECT 1 FROM internal_access_grants WHERE id = $generated_uuid LIMIT 1 {
+        error('a grant with the same grantee, original_credential_id, and locked_until already exists');
+    }
+
+    INSERT INTO credentials (id, human_id, credential_type, credential_level, credential_status, content, encryption_public_key, issuer, inserter)
+        VALUES ($id, $human_id, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key, $issuer, $wg_id::TEXT);
+
+    INSERT INTO shared_credentials (original_id, duplicate_id) VALUES ($original_credential_id, $id);
+
+    INSERT INTO internal_access_grants (id, ag_owner_human_id, ag_grantee, data_id, locked_until, write_grant_id)
+        VALUES (
+            $generated_uuid,
+            $human_id,
+            $grantee,
+            $id,
+            $locked_until,
+            $wg_id
+        );
+}
+
 @kgw(authn='true')
 procedure credential_exist_as_inserter($id uuid) public view returns (credential_exist bool) {
     get_inserter();
@@ -452,27 +535,54 @@ procedure get_credential_shared ($id uuid) public view returns table (id uuid, h
         error('the credential does not exist');
     }
 
-    $granted bool := false;
-    $grant_valid bool := false;
+    $ext_ag_granted bool := false;
+    $ext_ag_grant_valid bool := false;
+    $int_ag_granted bool := false;
 
-    for $row in SELECT status FROM external_access_grants WHERE data_id = $id::TEXT AND ag_grantee = @caller COLLATE NOCASE {
-        $granted := true;
-        if $row.status == 'valid' {
-            $grant_valid := true;
+    for $ext_ag_row in SELECT status FROM external_access_grants WHERE data_id = $id::TEXT AND ag_grantee = @caller COLLATE NOCASE {
+        $ext_ag_granted := true;
+        if $ext_ag_row.status == 'valid' {
+            $ext_ag_grant_valid := true;
             break;
         }
     }
 
-    if !$granted {
-        error('the credential is not shared with the caller');
+    for $int_ag_row in SELECT 1 FROM internal_access_grants WHERE data_id = $id AND ag_grantee = @caller COLLATE NOCASE {
+        $int_ag_granted := true;
     }
 
-    if !$grant_valid {
-        error('the credential has no valid access grant; for more details, call list_ag_statuses');
+    // We only keep valid internal AGs. So, we only need to double-check the validity for external AGs.
+    if !$int_ag_granted {
+        if !$ext_ag_granted {
+            error('the credential is not shared with the caller');
+        }
+
+        if !$ext_ag_grant_valid {
+            error('the credential has no valid access grant; for more details, call list_external_ag_statuses');
+        }
     }
 
     return SELECT id, human_id, credential_type, credential_level, credential_status, content, encryption_public_key,
         issuer, inserter FROM credentials WHERE id = $id;
+}
+
+procedure credential_belongs_to_human($id uuid, $human_id uuid) private view returns (belongs bool) {
+    for $row in SELECT 1 from credentials WHERE id = $id AND human_id = $human_id LIMIT 1 {
+        return true;
+    }
+
+    return false;
+}
+
+procedure credential_belongs_to_caller($id uuid) private view returns (belongs bool) {
+    for $row in SELECT 1 from credentials
+        WHERE id = $id
+        AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = @caller)) {
+        return true;
+    }
+
+    return false;
 }
 
 procedure credential_exist($id uuid) private view returns (credential_exist bool) {
@@ -480,6 +590,14 @@ procedure credential_exist($id uuid) private view returns (credential_exist bool
         return true;
     }
     return false;
+}
+
+procedure get_credential_inserter($id uuid) private view returns (inserter text) {
+    for $row in SELECT inserter FROM credentials WHERE id = $id LIMIT 1 {
+        return $row.inserter;
+    }
+
+    error('credential not found');
 }
 
 
@@ -559,27 +677,15 @@ procedure share_attribute($id uuid, $original_attribute_id uuid, $attribute_key 
 }
 
 
-// ACCEESS GRANTS ACTIONS
+// EXTERNAL ACCESS GRANTS ACTIONS
 
 @kgw(authn='true')
-procedure list_ag_statuses($data_id text) public view returns table (ag_owner text, ag_grantee text, locked_until int, status text) {
+procedure list_external_ag_statuses($data_id text) public view returns table (ag_owner text, ag_grantee text, locked_until int, status text) {
     return
         SELECT ag_owner, ag_grantee, locked_until, status
         FROM external_access_grants
         WHERE data_id = $data_id
           AND ag_grantee = @caller;
-}
-
-@kgw(authn='true')
-procedure has_locked_grants($id uuid) public view returns (has bool) {
-    for $row in SELECT 1 FROM external_access_grants
-            WHERE data_id = $id::TEXT
-            AND ag_owner = @caller COLLATE NOCASE
-            AND status = 'valid'
-            AND locked_until >= @block_timestamp LIMIT 1 {
-        return true;
-    }
-    return false;
 }
 
 // This procedure is used in an oracle resolution to determine the status of a AG at the moment of adding it into idOS
@@ -607,6 +713,100 @@ procedure define_ag_status_as_owner($ag_owner text, $ag_grantee text, $data_id u
         }
 
     return 'invalid_ag_owner_does_not_match_original_credential_owner';
+}
+
+
+// WRITE GRANTS ACTIONS
+
+procedure add_write_grant($wg_grantee text) public {
+    INSERT INTO write_grants (id, wg_owner, wg_grantee, wg_owner_human_id) VALUES (
+        uuid_generate_v5('31276fd4-105f-4ff7-9f64-644942c14b79'::uuid, format('%s-%s', @caller, $wg_grantee)),
+        @caller,
+        $wg_grantee,
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = @caller)
+        )
+    );
+}
+
+procedure remove_write_grant($wg_grantee text) public {
+    DELETE FROM write_grants
+        WHERE wg_grantee = $wg_grantee COLLATE NOCASE
+        AND wg_owner_human_id = (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = @caller));
+}
+
+procedure get_write_grant_id($human_id uuid) private view returns (id uuid) {
+    for $row in SELECT id FROM write_grants WHERE wg_owner_human_id = $human_id AND wg_grantee = @caller COLLATE NOCASE LIMIT 1 {
+        return $row.id;
+    }
+
+    error('there is no write grant found');
+}
+
+
+// INTERNAL ACCESS GRANTS ACTIONS
+
+procedure revoke_internal_access_grant ($id uuid) public {
+    $iag_exist := false;
+    for $row in SELECT 1 FROM internal_access_grants WHERE id = $id
+        AND ag_owner_human_id = (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = @caller)) {
+        $iag_exist := true;
+    }
+
+    if !$iag_exist {
+        error('the internal access grant not found');
+    }
+
+    for $row2 in SELECT 1 FROM internal_access_grants WHERE id = $id
+        AND locked_until >= @block_timestamp
+        AND ag_owner_human_id = (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = @caller)) {
+        error('the grant is locked');
+    }
+
+    DELETE FROM internal_access_grants
+    WHERE id = $id
+    AND ag_owner_human_id = (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = @caller));
+}
+
+procedure get_internal_ag_owned () public view returns table (id uuid, ag_owner_human_id uuid,
+    ag_grantee text, data_id uuid, locked_until int, write_grant_id uuid) {
+    return SELECT id, ag_owner_human_id, ag_grantee, data_id, locked_until, write_grant_id FROM internal_access_grants
+        WHERE ag_owner_human_id = (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = @caller));
+}
+
+procedure get_internal_ag_granted () public view returns table (id uuid, ag_owner_human_id uuid,
+    ag_grantee text, data_id uuid, locked_until int) {
+    return SELECT id, ag_owner_human_id, ag_grantee, data_id, locked_until FROM internal_access_grants
+        WHERE ag_grantee =  @caller;
+}
+
+
+// BOTH GRANTS ACTIONS
+
+@kgw(authn='true')
+procedure has_locked_grants($id uuid) public view returns (has bool) {
+    for $ext_row in SELECT 1 FROM external_access_grants
+            WHERE data_id = $id::TEXT
+            AND ag_owner = @caller COLLATE NOCASE
+            AND status = 'valid'
+            AND locked_until >= @block_timestamp LIMIT 1 {
+        return true;
+    }
+
+    for $int_row in SELECT 1 FROM internal_access_grants
+            WHERE data_id = $id
+            AND ag_owner_human_id = (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+                OR (wallet_type = 'NEAR' AND public_key = @caller))
+            AND locked_until >= @block_timestamp LIMIT 1 {
+        return true;
+    }
+
+    return false;
 }
 
 
@@ -657,16 +857,61 @@ procedure insert_shared_attr_as_owner($original_id uuid, $duplicate_id uuid) own
     VALUES ($original_id, $duplicate_id);
 }
 
-// ACTIONS FOR IN-SCHEMA DATA MIGRATION
+// Some entities no need special actions because main actions do the same
+// inserters:  add_inserter_as_owner
+// delegates: add_delegate_as_owner
+// configs: upsert_config_as_owner
 
-procedure all_humans_as_owner() public view owner returns table (id uuid, current_public_key text, inserter text){
+procedure insert_external_ags_as_owner($id uuid, $ag_owner text, $ag_grantee text, $data_id text,
+    $locked_until int, $ag_chain text, $tx_hash text, $block_hash text, $height int, $status text
+    ) owner public {
+    INSERT INTO external_access_grants (id, ag_owner, ag_grantee, data_id, locked_until, ag_chain,
+        tx_hash, block_hash, height, status)
+    VALUES ($id, $ag_owner, $ag_grantee, $data_id, $locked_until, $ag_chain,
+        $tx_hash, $block_hash, $height, $status);
+}
+
+procedure insert_internal_ags_as_owner($id uuid, $ag_owner_human_id uuid, $ag_grantee text, $data_id uuid,
+    $locked_until int, $write_grant_id uuid) owner public {
+    INSERT INTO internal_access_grants (id, ag_owner_human_id, ag_grantee, data_id, locked_until, write_grant_id)
+    VALUES ($id, $ag_owner_human_id, $ag_grantee, $data_id, $locked_until, $write_grant_id);
+}
+
+procedure insert_write_grants_as_owner($id uuid, $wg_owner text, $wg_grantee text, $wg_owner_human_id uuid) owner public {
+    INSERT INTO write_grants (id, wg_owner, wg_grantee, wg_owner_human_id)
+    VALUES ($id, $wg_owner, $wg_grantee, $wg_owner_human_id);
+}
+
+
+// ACTIONS FOR IN-SCHEMA DATA MIGRATION (OWNER)
+
+procedure all_humans_as_owner() public view owner returns table (id uuid, current_public_key text, inserter text) {
     return SELECT id, current_public_key, inserter FROM humans;
 }
 
+foreign procedure get_all_humans() returns table(id uuid, current_public_key text, inserter text)
+
+procedure migrate_humans($dbid text) public owner {
+    for $row in SELECT id, current_public_key, inserter FROM get_all_humans[$dbid, 'all_humans_as_owner']() {
+        INSERT INTO humans (id, current_public_key, inserter) VALUES ($row.id, $row.current_public_key, $row.inserter);
+    }
+}
+
 procedure all_wallets_as_owner() public view owner returns table (id uuid, human_id uuid, address text, public_key text,
-    wallet_type text, message text, signature text, inserter text) {
+wallet_type text, message text, signature text, inserter text) {
     return SELECT id, human_id, address, public_key, wallet_type, message, signature, inserter FROM wallets;
 }
+
+foreign procedure get_all_wallets() returns table (id uuid, human_id uuid, address text, public_key text,
+wallet_type text, message text, signature text, inserter text)
+
+procedure migrate_wallets($dbid text) public owner {
+    for $row in SELECT id, human_id, address, public_key, wallet_type, message, signature, inserter FROM get_all_wallets[$dbid, 'all_wallets_as_owner']() {
+        INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature, inserter)
+            VALUES ($row.id, $row.human_id, $row.address, $row.public_key, $row.wallet_type, $row.message, $row.signature, $row.inserter);
+    }
+}
+
 
 procedure all_credentials_as_owner() public view owner returns table (id uuid, human_id uuid, credential_type text,
     credential_level text, credential_status text, content text, encryption_public_key text, issuer text, inserter text) {
@@ -674,32 +919,162 @@ procedure all_credentials_as_owner() public view owner returns table (id uuid, h
         issuer, inserter FROM credentials;
 }
 
+foreign procedure get_all_credentials() returns table (id uuid, human_id uuid, credential_type text,
+credential_level text, credential_status text, content text, encryption_public_key text, issuer text, inserter text)
+
+procedure migrate_credentials($dbid text) public owner {
+    for $row in SELECT id, human_id, credential_type, credential_level, credential_status, content,
+        encryption_public_key, issuer, inserter FROM get_all_credentials[$dbid, 'all_credentials_as_owner']() {
+        INSERT INTO credentials (id, human_id, credential_type, credential_level, credential_status, content,
+            encryption_public_key, issuer, inserter)
+        VALUES ($row.id, $row.human_id, $row.credential_type, $row.credential_level, $row.credential_status, $row.content,
+            $row.encryption_public_key, $row.issuer, $row.inserter);
+    }
+}
+
+
 procedure all_shared_credentials_as_owner() public view owner returns table (original_id uuid, duplicate_id uuid) {
     return SELECT original_id, duplicate_id FROM shared_credentials;
 }
+
+foreign procedure get_all_shared_credentials() returns table (original_id uuid, duplicate_id uuid)
+
+procedure migrate_shared_credentials($dbid text) public owner {
+    for $row in SELECT original_id, duplicate_id FROM get_all_shared_credentials[$dbid, 'all_shared_credentials_as_owner']() {
+        INSERT INTO shared_credentials (original_id, duplicate_id) VALUES ($row.original_id, $row.duplicate_id);
+    }
+}
+
 
 procedure all_human_attributes_as_owner() public view owner returns table (id uuid, human_id uuid, attribute_key text,
     value text, inserter text) {
     return SELECT id, human_id, attribute_key, value, inserter FROM human_attributes;
 }
 
+foreign procedure get_all_human_attributes() returns table (id uuid, human_id uuid, attribute_key text, value text, inserter text)
+
+procedure migrate_human_attributes($dbid text) public owner {
+    for $row in SELECT id, human_id, attribute_key, value, inserter FROM get_all_human_attributes[$dbid, 'all_human_attributes_as_owner']() {
+        INSERT INTO human_attributes (id, human_id, attribute_key, value, inserter)
+        VALUES ($row.id, $row.human_id, $row.attribute_key, $row.value, $row.inserter);
+    }
+}
+
+
 procedure all_shared_human_attrs_as_owner() public view owner returns table (original_id uuid, duplicate_id uuid) {
     return SELECT original_id, duplicate_id FROM shared_human_attributes;
 }
+
+foreign procedure get_all_shared_human_attrs() returns table (original_id uuid, duplicate_id uuid)
+
+procedure migrate_shared_human_attrs($dbid text) public owner {
+    for $row in SELECT original_id, duplicate_id FROM get_all_shared_human_attrs[$dbid, 'all_shared_human_attrs_as_owner']() {
+        INSERT INTO shared_human_attributes (original_id, duplicate_id) VALUES ($row.original_id, $row.duplicate_id);
+    }
+}
+
 
 procedure all_inserters_as_owner() public view owner returns table (id uuid, name text) {
     return SELECT id, name FROM inserters;
 }
 
+foreign procedure get_all_inserters() returns table (id uuid, name text)
+
+procedure migrate_inserters($dbid text) public owner {
+    for $row in SELECT id, name FROM get_all_inserters[$dbid, 'all_inserters_as_owner']() {
+        INSERT INTO inserters (id, name) VALUES ($row.id, $row.name);
+    }
+}
+
+
 procedure all_delegates_as_owner() public view owner returns table (address text, inserter_id uuid) {
     return SELECT address, inserter_id FROM delegates;
 }
 
-procedure all_grants_as_owner() public view owner returns table (id uuid, ag_owner text, ag_grantee text,
+foreign procedure get_all_delegates() returns table (address text, inserter_id uuid)
+
+procedure migrate_delegates($dbid text) public owner {
+    for $row in SELECT address, inserter_id FROM get_all_delegates[$dbid, 'all_delegates_as_owner']() {
+        INSERT INTO delegates (address, inserter_id) VALUES ($row.address, $row.inserter_id);
+    }
+}
+
+
+procedure all_external_grants_as_owner() public view owner returns table (id uuid, ag_owner text, ag_grantee text,
     data_id text, locked_until int, ag_chain text, tx_hash text, height int, block_hash text) {
     return SELECT id, ag_owner, ag_grantee, data_id, locked_until, ag_chain, tx_hash, height, block_hash FROM external_access_grants;
 }
 
+foreign procedure get_all_external_grants() returns table (id uuid, ag_owner text, ag_grantee text,
+    data_id text, locked_until int, ag_chain text, tx_hash text, height int, block_hash text)
+
+procedure migrate_external_grants($dbid text) public owner {
+    for $row in SELECT id, ag_owner, ag_grantee, data_id, locked_until, ag_chain, tx_hash, height, block_hash
+        FROM get_all_external_grants[$dbid, 'all_external_grants_as_owner']() {
+        INSERT INTO external_access_grants (id, ag_owner, ag_grantee, data_id, locked_until, ag_chain, tx_hash, height, block_hash)
+            VALUES ($row.id, $row.ag_owner, $row.ag_grantee, $row.data_id, $row.locked_until, $row.ag_chain,
+            $row.tx_hash, $row.height, $row.block_hash);
+    }
+}
+
+
+procedure all_internal_grants_as_owner() public view owner returns table (id uuid, ag_owner_human_id uuid, ag_grantee text,
+    data_id uuid, locked_until int, write_grant_id uuid) {
+    return SELECT id, ag_owner_human_id, ag_grantee, data_id, locked_until, write_grant_id FROM internal_access_grants;
+}
+
+foreign procedure get_all_internal_grants() returns table (id uuid, ag_owner_human_id uuid, ag_grantee text,
+    data_id uuid, locked_until int, write_grant_id uuid)
+
+procedure migrate_internal_grants($dbid text) public owner {
+    for $row in SELECT id, ag_owner_human_id, ag_grantee, data_id, locked_until, write_grant_id
+        FROM get_all_internal_grants[$dbid, 'all_internal_grants_as_owner']() {
+        INSERT INTO internal_access_grants (id, ag_owner_human_id, ag_grantee, data_id, locked_until, write_grant_id)
+            VALUES ($row.id, $row.ag_owner_human_id, $row.ag_grantee, $row.data_id, $row.locked_until, $row.write_grant_id);
+    }
+}
+
+
+procedure all_write_grants_as_owner() public view owner returns table (id uuid, wg_owner text, wg_grantee text,
+    wg_owner_human_id uuid) {
+    return SELECT id, wg_owner, wg_grantee, wg_owner_human_id FROM write_grants;
+}
+
+foreign procedure get_all_write_grants() returns table (id uuid, wg_owner text, wg_grantee text, wg_owner_human_id uuid)
+
+procedure migrate_write_grants($dbid text) public owner {
+    for $row in SELECT id, wg_owner, wg_grantee, wg_owner_human_id FROM get_all_write_grants[$dbid, 'all_write_grants_as_owner']() {
+        INSERT INTO write_grants (id, wg_owner, wg_grantee, wg_owner_human_id)
+            VALUES ($row.id, $row.wg_owner, $row.wg_grantee, $row.wg_owner_human_id);
+    }
+}
+
+
 procedure all_configs_as_owner() public view owner returns table (config_key text, value text) {
     return SELECT config_key, value FROM configs;
+}
+
+foreign procedure get_all_configs() returns table (config_key text, value text)
+
+procedure migrate_configs($dbid text) public owner {
+    for $row in SELECT config_key, value FROM get_all_configs[$dbid, 'all_configs_as_owner']() {
+        INSERT INTO configs (config_key, value)
+            VALUES ($row.config_key, $row.value);
+    }
+}
+
+// The sequence of inserting of tables is important
+procedure migrate_all_data($old_dbid text) public owner {
+    migrate_humans($old_dbid);
+    migrate_wallets($old_dbid);
+    migrate_credentials($old_dbid);
+    migrate_shared_credentials($old_dbid);
+    migrate_human_attributes($old_dbid);
+    migrate_shared_human_attrs($old_dbid);
+    migrate_inserters($old_dbid);
+    migrate_delegates($old_dbid);
+    migrate_external_grants($old_dbid);
+    migrate_write_grants($old_dbid); // WGs must be inserted before internal AGs
+    migrate_internal_grants($old_dbid);
+    migrate_configs($old_dbid);
 }

--- a/schema.staging.kf
+++ b/schema.staging.kf
@@ -354,7 +354,7 @@ procedure add_credential_by_write_grant(
 // TODO: change to procedure
 @kgw(authn='true')
 action get_credentials() public view {
-	SELECT DISTINCT c.id, c.human_id, c.inserter, c.credential_type, c.credential_level, c.credential_status, c.issuer, sc.original_id AS original_id
+    SELECT DISTINCT c.id, c.human_id, c.inserter, c.credential_type, c.credential_level, c.credential_status, c.issuer, sc.original_id AS original_id
     FROM credentials AS c
     LEFT JOIN shared_credentials AS sc ON c.id = sc.duplicate_id
     INNER JOIN wallets ON c.human_id = wallets.human_id
@@ -623,7 +623,7 @@ procedure add_attribute($id uuid, $attribute_key text, $value text) public {
 // TODO: change to procedure
 @kgw(authn='true')
 action get_attributes() public view {
-	SELECT DISTINCT ha.id, ha.human_id, ha.attribute_key, ha.value, sha.original_id AS original_id
+    SELECT DISTINCT ha.id, ha.human_id, ha.attribute_key, ha.value, sha.original_id AS original_id
     FROM human_attributes AS ha
     LEFT JOIN shared_human_attributes AS sha ON ha.id = sha.duplicate_id
     INNER JOIN wallets ON ha.human_id = wallets.human_id

--- a/schema.staging.kf
+++ b/schema.staging.kf
@@ -7,8 +7,6 @@ use idos as idos;
 
 // TABLES
 
-// TABLES
-
 table humans {
     id uuid primary,
     current_public_key text notnull,
@@ -48,6 +46,7 @@ table shared_credentials {
     original_id uuid notnull,
     duplicate_id uuid notnull,
     #primary_key primary(original_id, duplicate_id),
+    #shared_credentials_duplicate_id index(duplicate_id),
     foreign_key (original_id) references credentials(id) on_delete cascade,
     foreign_key (duplicate_id) references credentials(id) on_delete cascade
 }
@@ -85,12 +84,13 @@ table access_grants {
     id uuid primary,
     ag_owner text notnull,
     ag_grantee text notnull,
-    data_id uuid notnull,
+    data_id text notnull,
     locked_until int,
     ag_chain text notnull,
     tx_hash text,
     block_hash text,
     height int,
+    status text,
     #access_grants_data_id_grantee index(data_id, ag_grantee),
     #access_grants_data_id_owner index(data_id, ag_owner)
 }
@@ -429,10 +429,7 @@ action share_credential_through_dag (
 @kgw(authn='true')
 procedure credential_exist_as_inserter($id uuid) public view returns (credential_exist bool) {
     get_inserter();
-    for $row in SELECT 1 FROM credentials WHERE id = $id {
-        return true;
-    }
-    return false;
+    return credential_exist($id);
 }
 
 // TODO: change to procedure
@@ -451,12 +448,38 @@ action get_credential_owned ($id) public view {
 @kgw(authn='true')
 procedure get_credential_shared ($id uuid) public view returns table (id uuid, human_id uuid, credential_type text,
     credential_level text, credential_status text, content text, encryption_public_key text, issuer text, inserter text) {
-    if !has_grants($id) {
-        error('caller does not have access');
+    if !credential_exist($id) {
+        error('the credential does not exist');
+    }
+
+    $granted bool := false;
+    $grant_valid bool := false;
+
+    for $row in SELECT status FROM access_grants WHERE data_id = $id::TEXT AND ag_grantee = @caller COLLATE NOCASE {
+        $granted := true;
+        if $row.status == 'valid' {
+            $grant_valid := true;
+            break;
+        }
+    }
+
+    if !$granted {
+        error('the credential is not shared with the caller');
+    }
+
+    if !$grant_valid {
+        error('the credential has no valid access grant; for more details, call list_ag_statuses');
     }
 
     return SELECT id, human_id, credential_type, credential_level, credential_status, content, encryption_public_key,
         issuer, inserter FROM credentials WHERE id = $id;
+}
+
+procedure credential_exist($id uuid) private view returns (credential_exist bool) {
+    for $row in SELECT 1 FROM credentials WHERE id = $id {
+        return true;
+    }
+    return false;
 }
 
 
@@ -539,19 +562,51 @@ procedure share_attribute($id uuid, $original_attribute_id uuid, $attribute_key 
 // ACCEESS GRANTS ACTIONS
 
 @kgw(authn='true')
-procedure has_grants($id uuid) public view returns (granted bool) {
-    for $row in SELECT 1 FROM access_grants WHERE data_id = $id AND ag_grantee = @caller COLLATE NOCASE LIMIT 1 {
+procedure list_ag_statuses($data_id text) public view returns table (ag_owner text, ag_grantee text, locked_until int, status text) {
+    return
+        SELECT ag_owner, ag_grantee, locked_until, status
+        FROM access_grants
+        WHERE data_id = $data_id
+          AND ag_grantee = @caller;
+}
+
+@kgw(authn='true')
+procedure has_locked_grants($id uuid) public view returns (has bool) {
+    for $row in SELECT 1 FROM access_grants
+            WHERE data_id = $id::TEXT
+            AND ag_owner = @caller COLLATE NOCASE
+            AND status = 'valid'
+            AND locked_until >= @block_timestamp LIMIT 1 {
         return true;
     }
     return false;
 }
 
-@kgw(authn='true')
-procedure has_locked_grants($id uuid) public view returns (has bool) {
-    for $row in SELECT 1 FROM access_grants WHERE data_id = $id AND ag_owner = @caller COLLATE NOCASE AND locked_until >= @block_timestamp LIMIT 1 {
-        return true;
+// This procedure is used in an oracle resolution to determine the status of a AG at the moment of adding it into idOS
+// It needs to be done at this moment because of later defining data can change (original credential deleted, owner wallet or profile removed etc.)
+procedure define_ag_status_as_owner($ag_owner text, $ag_grantee text, $data_id uuid) public view owner returns (status text) {
+    if !credential_exist($data_id) {
+        return 'invalid_data_id_not_found';
     }
-    return false;
+
+    $data_id_is_duplicate := false;
+    for $row in SELECT 1 FROM shared_credentials WHERE duplicate_id = $data_id LIMIT 1 {
+        $data_id_is_duplicate := true;
+    }
+    if !$data_id_is_duplicate {
+        return 'invalid_data_id_is_not_a_duplicate';
+    }
+
+    for $row2 in SELECT 1 FROM wallets
+        INNER JOIN credentials ON credentials.human_id = wallets.human_id
+        WHERE credentials.id = $data_id
+        AND ((wallets.address = $ag_owner COLLATE NOCASE AND wallets.wallet_type = 'EVM')
+            OR (wallets.public_key = $ag_owner COLLATE NOCASE AND wallets.wallet_type = 'NEAR'))
+        LIMIT 1 {
+            return 'valid';
+        }
+
+    return 'invalid_ag_owner_does_not_match_original_credential_owner';
 }
 
 
@@ -641,7 +696,7 @@ procedure all_delegates_as_owner() public view owner returns table (address text
 }
 
 procedure all_grants_as_owner() public view owner returns table (id uuid, ag_owner text, ag_grantee text,
-    data_id uuid, locked_until int, ag_chain text, tx_hash text, height int, block_hash text) {
+    data_id text, locked_until int, ag_chain text, tx_hash text, height int, block_hash text) {
     return SELECT id, ag_owner, ag_grantee, data_id, locked_until, ag_chain, tx_hash, height, block_hash FROM access_grants;
 }
 

--- a/schema.staging.kf
+++ b/schema.staging.kf
@@ -33,9 +33,9 @@ table credentials {
     human_id uuid notnull,
     credential_type text notnull,
     credential_level text,
-    credential_status text,
+    credential_status text, // idOS credential's status, not VC status (VC statuses are managed inside VC content and revocations mechanism)
     content text notnull,
-    encryption_public_key text notnull,
+    encryption_public_key text notnull, // public key of encryptor
     issuer text notnull,
     inserter text,
     #credentials_human_id index(human_id),
@@ -90,9 +90,33 @@ table external_access_grants {
     tx_hash text,
     block_hash text,
     height int,
-    status text,
+    // data_id in contract can be any data, but idOS expects uuid of a credential, so we need a status field to mark validity of the access grant
+    status text, // valid, invalid_by_reason, ...
     #external_ag_data_id_grantee index(data_id, ag_grantee),
     #external_ag_data_id_owner index(data_id, ag_owner)
+}
+
+// A human/user gives a grant to write data (create a credential, share the credential) on his behalf to some issuer
+table write_grants {
+    id uuid primary,
+    wg_owner text notnull, // human wallet/pk
+    wg_grantee text notnull, // issuer wallet/pk
+    wg_owner_human_id uuid notnull, // human's id, to be sure we will find the human if the owner's wallet will be deleted
+    #write_grants_human_id_grantee unique(wg_owner_human_id, wg_grantee)
+}
+
+// internal access grants can be granted if such permission is in write_grants
+table internal_access_grants {
+    id uuid primary,
+    ag_owner_human_id uuid notnull,
+    ag_grantee text notnull,
+    data_id uuid notnull,
+    locked_until int notnull default(0),
+    write_grant_id uuid, // This should be notnull, but we do set it to null in the FK.
+    foreign_key (write_grant_id) references write_grants(id) on_delete set null,
+    #iag_data_id index(data_id),
+    #iag_ag_grantee index(ag_grantee),
+    #iag_ag_owner_human_id index(ag_owner_human_id)
 }
 
 table configs {
@@ -311,10 +335,26 @@ procedure add_credential($id uuid, $credential_type text, $credential_level text
     );
 }
 
+procedure add_credential_by_write_grant(
+    $id uuid,
+    $human_id uuid,
+    $credential_type text,
+    $credential_level text,
+    $credential_status text,
+    $content text,
+    $encryption_public_key text,
+    $issuer text) public {
+
+    $wg_id := get_write_grant_id($human_id); // throw an error if no write_grant
+
+    INSERT INTO credentials (id, human_id, credential_type, credential_level, credential_status, content, encryption_public_key, issuer, inserter)
+    VALUES ($id, $human_id, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key, $issuer, $wg_id::TEXT);
+}
+
 // TODO: change to procedure
 @kgw(authn='true')
 action get_credentials() public view {
-	SELECT DISTINCT c.id, c.human_id, c.inserter, c.credential_type, c.credential_level, c.credential_status, sc.original_id AS original_id
+	SELECT DISTINCT c.id, c.human_id, c.inserter, c.credential_type, c.credential_level, c.credential_status, c.issuer, sc.original_id AS original_id
     FROM credentials AS c
     LEFT JOIN shared_credentials AS sc ON c.id = sc.duplicate_id
     INNER JOIN wallets ON c.human_id = wallets.human_id
@@ -346,6 +386,10 @@ action edit_credential($id, $credential_type, $credential_level, $credential_sta
 }
 
 procedure remove_credential($id uuid) public {
+    if !credential_belongs_to_caller($id) {
+        error('the credential does not belong to the caller');
+    }
+
     if has_locked_grants($id) {
         error('there are locked grants for this credential');
     }
@@ -354,6 +398,8 @@ procedure remove_credential($id uuid) public {
     AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
         OR (wallet_type = 'NEAR' AND public_key = @caller)
     );
+
+    DELETE FROM internal_access_grants WHERE data_id = $id;
 }
 
 // Do we need this procedure? Can share_credential_through_dag cover all cases?
@@ -367,23 +413,12 @@ procedure share_credential(
         $encryption_public_key text,
         $issuer text) public {
 
-    if !credential_belongs_to_human($original_credential_id) {
+    if !credential_belongs_to_caller($original_credential_id) {
         error('The original credential does not belong to the caller');
     }
 
     add_credential($id, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key, $issuer);
     INSERT INTO shared_credentials (original_id, duplicate_id) VALUES ($original_credential_id, $id);
-}
-
-procedure credential_belongs_to_human($id uuid) private returns (belongs bool) {
-    for $row in SELECT 1 from credentials
-        WHERE id = $id
-        AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
-            OR (wallet_type = 'NEAR' AND public_key = @caller)) {
-        return true;
-    }
-
-    return false;
 }
 
 action share_credential_through_dag (
@@ -426,6 +461,54 @@ action share_credential_through_dag (
     INSERT INTO shared_credentials (original_id, duplicate_id) VALUES ($original_credential_id, $id);
 }
 
+procedure share_credential_by_write_grant(
+    $id uuid,
+    $human_id uuid,
+    $original_credential_id uuid,
+    $credential_type text,
+    $credential_level text,
+    $credential_status text,
+    $content text,
+    $encryption_public_key text,
+    $grantee text,
+    $locked_until int,
+    $issuer text) public {
+
+    if $locked_until < 0 {
+        error('locked_until must be positive integer timestamp or zero');
+    }
+
+    $wg_id := get_write_grant_id($human_id); // throw an error if no write_grant
+
+    if !credential_belongs_to_human($original_credential_id, $human_id) {
+        error('the original credential does not belong to the human');
+    }
+
+    if $wg_id::TEXT != get_credential_inserter($original_credential_id) {
+        error('you can share only original credentials you created');
+    }
+
+    $generated_uuid := uuid_generate_v5('31276fd4-105f-4ff7-9f64-644942c14b79'::uuid, format('%s-%s-%s', $grantee, $original_credential_id, $locked_until));
+    for $row in SELECT 1 FROM internal_access_grants WHERE id = $generated_uuid LIMIT 1 {
+        error('a grant with the same grantee, original_credential_id, and locked_until already exists');
+    }
+
+    INSERT INTO credentials (id, human_id, credential_type, credential_level, credential_status, content, encryption_public_key, issuer, inserter)
+        VALUES ($id, $human_id, $credential_type, $credential_level, $credential_status, $content, $encryption_public_key, $issuer, $wg_id::TEXT);
+
+    INSERT INTO shared_credentials (original_id, duplicate_id) VALUES ($original_credential_id, $id);
+
+    INSERT INTO internal_access_grants (id, ag_owner_human_id, ag_grantee, data_id, locked_until, write_grant_id)
+        VALUES (
+            $generated_uuid,
+            $human_id,
+            $grantee,
+            $id,
+            $locked_until,
+            $wg_id
+        );
+}
+
 @kgw(authn='true')
 procedure credential_exist_as_inserter($id uuid) public view returns (credential_exist bool) {
     get_inserter();
@@ -452,27 +535,54 @@ procedure get_credential_shared ($id uuid) public view returns table (id uuid, h
         error('the credential does not exist');
     }
 
-    $granted bool := false;
-    $grant_valid bool := false;
+    $ext_ag_granted bool := false;
+    $ext_ag_grant_valid bool := false;
+    $int_ag_granted bool := false;
 
-    for $row in SELECT status FROM external_access_grants WHERE data_id = $id::TEXT AND ag_grantee = @caller COLLATE NOCASE {
-        $granted := true;
-        if $row.status == 'valid' {
-            $grant_valid := true;
+    for $ext_ag_row in SELECT status FROM external_access_grants WHERE data_id = $id::TEXT AND ag_grantee = @caller COLLATE NOCASE {
+        $ext_ag_granted := true;
+        if $ext_ag_row.status == 'valid' {
+            $ext_ag_grant_valid := true;
             break;
         }
     }
 
-    if !$granted {
-        error('the credential is not shared with the caller');
+    for $int_ag_row in SELECT 1 FROM internal_access_grants WHERE data_id = $id AND ag_grantee = @caller COLLATE NOCASE {
+        $int_ag_granted := true;
     }
 
-    if !$grant_valid {
-        error('the credential has no valid access grant; for more details, call list_ag_statuses');
+    // We only keep valid internal AGs. So, we only need to double-check the validity for external AGs.
+    if !$int_ag_granted {
+        if !$ext_ag_granted {
+            error('the credential is not shared with the caller');
+        }
+
+        if !$ext_ag_grant_valid {
+            error('the credential has no valid access grant; for more details, call list_external_ag_statuses');
+        }
     }
 
     return SELECT id, human_id, credential_type, credential_level, credential_status, content, encryption_public_key,
         issuer, inserter FROM credentials WHERE id = $id;
+}
+
+procedure credential_belongs_to_human($id uuid, $human_id uuid) private view returns (belongs bool) {
+    for $row in SELECT 1 from credentials WHERE id = $id AND human_id = $human_id LIMIT 1 {
+        return true;
+    }
+
+    return false;
+}
+
+procedure credential_belongs_to_caller($id uuid) private view returns (belongs bool) {
+    for $row in SELECT 1 from credentials
+        WHERE id = $id
+        AND human_id=(SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = @caller)) {
+        return true;
+    }
+
+    return false;
 }
 
 procedure credential_exist($id uuid) private view returns (credential_exist bool) {
@@ -480,6 +590,14 @@ procedure credential_exist($id uuid) private view returns (credential_exist bool
         return true;
     }
     return false;
+}
+
+procedure get_credential_inserter($id uuid) private view returns (inserter text) {
+    for $row in SELECT inserter FROM credentials WHERE id = $id LIMIT 1 {
+        return $row.inserter;
+    }
+
+    error('credential not found');
 }
 
 
@@ -559,27 +677,15 @@ procedure share_attribute($id uuid, $original_attribute_id uuid, $attribute_key 
 }
 
 
-// ACCEESS GRANTS ACTIONS
+// EXTERNAL ACCESS GRANTS ACTIONS
 
 @kgw(authn='true')
-procedure list_ag_statuses($data_id text) public view returns table (ag_owner text, ag_grantee text, locked_until int, status text) {
+procedure list_external_ag_statuses($data_id text) public view returns table (ag_owner text, ag_grantee text, locked_until int, status text) {
     return
         SELECT ag_owner, ag_grantee, locked_until, status
         FROM external_access_grants
         WHERE data_id = $data_id
           AND ag_grantee = @caller;
-}
-
-@kgw(authn='true')
-procedure has_locked_grants($id uuid) public view returns (has bool) {
-    for $row in SELECT 1 FROM external_access_grants
-            WHERE data_id = $id::TEXT
-            AND ag_owner = @caller COLLATE NOCASE
-            AND status = 'valid'
-            AND locked_until >= @block_timestamp LIMIT 1 {
-        return true;
-    }
-    return false;
 }
 
 // This procedure is used in an oracle resolution to determine the status of a AG at the moment of adding it into idOS
@@ -607,6 +713,100 @@ procedure define_ag_status_as_owner($ag_owner text, $ag_grantee text, $data_id u
         }
 
     return 'invalid_ag_owner_does_not_match_original_credential_owner';
+}
+
+
+// WRITE GRANTS ACTIONS
+
+procedure add_write_grant($wg_grantee text) public {
+    INSERT INTO write_grants (id, wg_owner, wg_grantee, wg_owner_human_id) VALUES (
+        uuid_generate_v5('31276fd4-105f-4ff7-9f64-644942c14b79'::uuid, format('%s-%s', @caller, $wg_grantee)),
+        @caller,
+        $wg_grantee,
+        (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = @caller)
+        )
+    );
+}
+
+procedure remove_write_grant($wg_grantee text) public {
+    DELETE FROM write_grants
+        WHERE wg_grantee = $wg_grantee COLLATE NOCASE
+        AND wg_owner_human_id = (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = @caller));
+}
+
+procedure get_write_grant_id($human_id uuid) private view returns (id uuid) {
+    for $row in SELECT id FROM write_grants WHERE wg_owner_human_id = $human_id AND wg_grantee = @caller COLLATE NOCASE LIMIT 1 {
+        return $row.id;
+    }
+
+    error('there is no write grant found');
+}
+
+
+// INTERNAL ACCESS GRANTS ACTIONS
+
+procedure revoke_internal_access_grant ($id uuid) public {
+    $iag_exist := false;
+    for $row in SELECT 1 FROM internal_access_grants WHERE id = $id
+        AND ag_owner_human_id = (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = @caller)) {
+        $iag_exist := true;
+    }
+
+    if !$iag_exist {
+        error('the internal access grant not found');
+    }
+
+    for $row2 in SELECT 1 FROM internal_access_grants WHERE id = $id
+        AND locked_until >= @block_timestamp
+        AND ag_owner_human_id = (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = @caller)) {
+        error('the grant is locked');
+    }
+
+    DELETE FROM internal_access_grants
+    WHERE id = $id
+    AND ag_owner_human_id = (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+        OR (wallet_type = 'NEAR' AND public_key = @caller));
+}
+
+procedure get_internal_ag_owned () public view returns table (id uuid, ag_owner_human_id uuid,
+    ag_grantee text, data_id uuid, locked_until int, write_grant_id uuid) {
+    return SELECT id, ag_owner_human_id, ag_grantee, data_id, locked_until, write_grant_id FROM internal_access_grants
+        WHERE ag_owner_human_id = (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+            OR (wallet_type = 'NEAR' AND public_key = @caller));
+}
+
+procedure get_internal_ag_granted () public view returns table (id uuid, ag_owner_human_id uuid,
+    ag_grantee text, data_id uuid, locked_until int) {
+    return SELECT id, ag_owner_human_id, ag_grantee, data_id, locked_until FROM internal_access_grants
+        WHERE ag_grantee =  @caller;
+}
+
+
+// BOTH GRANTS ACTIONS
+
+@kgw(authn='true')
+procedure has_locked_grants($id uuid) public view returns (has bool) {
+    for $ext_row in SELECT 1 FROM external_access_grants
+            WHERE data_id = $id::TEXT
+            AND ag_owner = @caller COLLATE NOCASE
+            AND status = 'valid'
+            AND locked_until >= @block_timestamp LIMIT 1 {
+        return true;
+    }
+
+    for $int_row in SELECT 1 FROM internal_access_grants
+            WHERE data_id = $id
+            AND ag_owner_human_id = (SELECT DISTINCT human_id FROM wallets WHERE (wallet_type = 'EVM' AND address=@caller COLLATE NOCASE)
+                OR (wallet_type = 'NEAR' AND public_key = @caller))
+            AND locked_until >= @block_timestamp LIMIT 1 {
+        return true;
+    }
+
+    return false;
 }
 
 
@@ -657,16 +857,61 @@ procedure insert_shared_attr_as_owner($original_id uuid, $duplicate_id uuid) own
     VALUES ($original_id, $duplicate_id);
 }
 
-// ACTIONS FOR IN-SCHEMA DATA MIGRATION
+// Some entities no need special actions because main actions do the same
+// inserters:  add_inserter_as_owner
+// delegates: add_delegate_as_owner
+// configs: upsert_config_as_owner
 
-procedure all_humans_as_owner() public view owner returns table (id uuid, current_public_key text, inserter text){
+procedure insert_external_ags_as_owner($id uuid, $ag_owner text, $ag_grantee text, $data_id text,
+    $locked_until int, $ag_chain text, $tx_hash text, $block_hash text, $height int, $status text
+    ) owner public {
+    INSERT INTO external_access_grants (id, ag_owner, ag_grantee, data_id, locked_until, ag_chain,
+        tx_hash, block_hash, height, status)
+    VALUES ($id, $ag_owner, $ag_grantee, $data_id, $locked_until, $ag_chain,
+        $tx_hash, $block_hash, $height, $status);
+}
+
+procedure insert_internal_ags_as_owner($id uuid, $ag_owner_human_id uuid, $ag_grantee text, $data_id uuid,
+    $locked_until int, $write_grant_id uuid) owner public {
+    INSERT INTO internal_access_grants (id, ag_owner_human_id, ag_grantee, data_id, locked_until, write_grant_id)
+    VALUES ($id, $ag_owner_human_id, $ag_grantee, $data_id, $locked_until, $write_grant_id);
+}
+
+procedure insert_write_grants_as_owner($id uuid, $wg_owner text, $wg_grantee text, $wg_owner_human_id uuid) owner public {
+    INSERT INTO write_grants (id, wg_owner, wg_grantee, wg_owner_human_id)
+    VALUES ($id, $wg_owner, $wg_grantee, $wg_owner_human_id);
+}
+
+
+// ACTIONS FOR IN-SCHEMA DATA MIGRATION (OWNER)
+
+procedure all_humans_as_owner() public view owner returns table (id uuid, current_public_key text, inserter text) {
     return SELECT id, current_public_key, inserter FROM humans;
 }
 
+foreign procedure get_all_humans() returns table(id uuid, current_public_key text, inserter text)
+
+procedure migrate_humans($dbid text) public owner {
+    for $row in SELECT id, current_public_key, inserter FROM get_all_humans[$dbid, 'all_humans_as_owner']() {
+        INSERT INTO humans (id, current_public_key, inserter) VALUES ($row.id, $row.current_public_key, $row.inserter);
+    }
+}
+
 procedure all_wallets_as_owner() public view owner returns table (id uuid, human_id uuid, address text, public_key text,
-    wallet_type text, message text, signature text, inserter text) {
+wallet_type text, message text, signature text, inserter text) {
     return SELECT id, human_id, address, public_key, wallet_type, message, signature, inserter FROM wallets;
 }
+
+foreign procedure get_all_wallets() returns table (id uuid, human_id uuid, address text, public_key text,
+wallet_type text, message text, signature text, inserter text)
+
+procedure migrate_wallets($dbid text) public owner {
+    for $row in SELECT id, human_id, address, public_key, wallet_type, message, signature, inserter FROM get_all_wallets[$dbid, 'all_wallets_as_owner']() {
+        INSERT INTO wallets (id, human_id, address, public_key, wallet_type, message, signature, inserter)
+            VALUES ($row.id, $row.human_id, $row.address, $row.public_key, $row.wallet_type, $row.message, $row.signature, $row.inserter);
+    }
+}
+
 
 procedure all_credentials_as_owner() public view owner returns table (id uuid, human_id uuid, credential_type text,
     credential_level text, credential_status text, content text, encryption_public_key text, issuer text, inserter text) {
@@ -674,32 +919,162 @@ procedure all_credentials_as_owner() public view owner returns table (id uuid, h
         issuer, inserter FROM credentials;
 }
 
+foreign procedure get_all_credentials() returns table (id uuid, human_id uuid, credential_type text,
+credential_level text, credential_status text, content text, encryption_public_key text, issuer text, inserter text)
+
+procedure migrate_credentials($dbid text) public owner {
+    for $row in SELECT id, human_id, credential_type, credential_level, credential_status, content,
+        encryption_public_key, issuer, inserter FROM get_all_credentials[$dbid, 'all_credentials_as_owner']() {
+        INSERT INTO credentials (id, human_id, credential_type, credential_level, credential_status, content,
+            encryption_public_key, issuer, inserter)
+        VALUES ($row.id, $row.human_id, $row.credential_type, $row.credential_level, $row.credential_status, $row.content,
+            $row.encryption_public_key, $row.issuer, $row.inserter);
+    }
+}
+
+
 procedure all_shared_credentials_as_owner() public view owner returns table (original_id uuid, duplicate_id uuid) {
     return SELECT original_id, duplicate_id FROM shared_credentials;
 }
+
+foreign procedure get_all_shared_credentials() returns table (original_id uuid, duplicate_id uuid)
+
+procedure migrate_shared_credentials($dbid text) public owner {
+    for $row in SELECT original_id, duplicate_id FROM get_all_shared_credentials[$dbid, 'all_shared_credentials_as_owner']() {
+        INSERT INTO shared_credentials (original_id, duplicate_id) VALUES ($row.original_id, $row.duplicate_id);
+    }
+}
+
 
 procedure all_human_attributes_as_owner() public view owner returns table (id uuid, human_id uuid, attribute_key text,
     value text, inserter text) {
     return SELECT id, human_id, attribute_key, value, inserter FROM human_attributes;
 }
 
+foreign procedure get_all_human_attributes() returns table (id uuid, human_id uuid, attribute_key text, value text, inserter text)
+
+procedure migrate_human_attributes($dbid text) public owner {
+    for $row in SELECT id, human_id, attribute_key, value, inserter FROM get_all_human_attributes[$dbid, 'all_human_attributes_as_owner']() {
+        INSERT INTO human_attributes (id, human_id, attribute_key, value, inserter)
+        VALUES ($row.id, $row.human_id, $row.attribute_key, $row.value, $row.inserter);
+    }
+}
+
+
 procedure all_shared_human_attrs_as_owner() public view owner returns table (original_id uuid, duplicate_id uuid) {
     return SELECT original_id, duplicate_id FROM shared_human_attributes;
 }
+
+foreign procedure get_all_shared_human_attrs() returns table (original_id uuid, duplicate_id uuid)
+
+procedure migrate_shared_human_attrs($dbid text) public owner {
+    for $row in SELECT original_id, duplicate_id FROM get_all_shared_human_attrs[$dbid, 'all_shared_human_attrs_as_owner']() {
+        INSERT INTO shared_human_attributes (original_id, duplicate_id) VALUES ($row.original_id, $row.duplicate_id);
+    }
+}
+
 
 procedure all_inserters_as_owner() public view owner returns table (id uuid, name text) {
     return SELECT id, name FROM inserters;
 }
 
+foreign procedure get_all_inserters() returns table (id uuid, name text)
+
+procedure migrate_inserters($dbid text) public owner {
+    for $row in SELECT id, name FROM get_all_inserters[$dbid, 'all_inserters_as_owner']() {
+        INSERT INTO inserters (id, name) VALUES ($row.id, $row.name);
+    }
+}
+
+
 procedure all_delegates_as_owner() public view owner returns table (address text, inserter_id uuid) {
     return SELECT address, inserter_id FROM delegates;
 }
 
-procedure all_grants_as_owner() public view owner returns table (id uuid, ag_owner text, ag_grantee text,
+foreign procedure get_all_delegates() returns table (address text, inserter_id uuid)
+
+procedure migrate_delegates($dbid text) public owner {
+    for $row in SELECT address, inserter_id FROM get_all_delegates[$dbid, 'all_delegates_as_owner']() {
+        INSERT INTO delegates (address, inserter_id) VALUES ($row.address, $row.inserter_id);
+    }
+}
+
+
+procedure all_external_grants_as_owner() public view owner returns table (id uuid, ag_owner text, ag_grantee text,
     data_id text, locked_until int, ag_chain text, tx_hash text, height int, block_hash text) {
     return SELECT id, ag_owner, ag_grantee, data_id, locked_until, ag_chain, tx_hash, height, block_hash FROM external_access_grants;
 }
 
+foreign procedure get_all_external_grants() returns table (id uuid, ag_owner text, ag_grantee text,
+    data_id text, locked_until int, ag_chain text, tx_hash text, height int, block_hash text)
+
+procedure migrate_external_grants($dbid text) public owner {
+    for $row in SELECT id, ag_owner, ag_grantee, data_id, locked_until, ag_chain, tx_hash, height, block_hash
+        FROM get_all_external_grants[$dbid, 'all_external_grants_as_owner']() {
+        INSERT INTO external_access_grants (id, ag_owner, ag_grantee, data_id, locked_until, ag_chain, tx_hash, height, block_hash)
+            VALUES ($row.id, $row.ag_owner, $row.ag_grantee, $row.data_id, $row.locked_until, $row.ag_chain,
+            $row.tx_hash, $row.height, $row.block_hash);
+    }
+}
+
+
+procedure all_internal_grants_as_owner() public view owner returns table (id uuid, ag_owner_human_id uuid, ag_grantee text,
+    data_id uuid, locked_until int, write_grant_id uuid) {
+    return SELECT id, ag_owner_human_id, ag_grantee, data_id, locked_until, write_grant_id FROM internal_access_grants;
+}
+
+foreign procedure get_all_internal_grants() returns table (id uuid, ag_owner_human_id uuid, ag_grantee text,
+    data_id uuid, locked_until int, write_grant_id uuid)
+
+procedure migrate_internal_grants($dbid text) public owner {
+    for $row in SELECT id, ag_owner_human_id, ag_grantee, data_id, locked_until, write_grant_id
+        FROM get_all_internal_grants[$dbid, 'all_internal_grants_as_owner']() {
+        INSERT INTO internal_access_grants (id, ag_owner_human_id, ag_grantee, data_id, locked_until, write_grant_id)
+            VALUES ($row.id, $row.ag_owner_human_id, $row.ag_grantee, $row.data_id, $row.locked_until, $row.write_grant_id);
+    }
+}
+
+
+procedure all_write_grants_as_owner() public view owner returns table (id uuid, wg_owner text, wg_grantee text,
+    wg_owner_human_id uuid) {
+    return SELECT id, wg_owner, wg_grantee, wg_owner_human_id FROM write_grants;
+}
+
+foreign procedure get_all_write_grants() returns table (id uuid, wg_owner text, wg_grantee text, wg_owner_human_id uuid)
+
+procedure migrate_write_grants($dbid text) public owner {
+    for $row in SELECT id, wg_owner, wg_grantee, wg_owner_human_id FROM get_all_write_grants[$dbid, 'all_write_grants_as_owner']() {
+        INSERT INTO write_grants (id, wg_owner, wg_grantee, wg_owner_human_id)
+            VALUES ($row.id, $row.wg_owner, $row.wg_grantee, $row.wg_owner_human_id);
+    }
+}
+
+
 procedure all_configs_as_owner() public view owner returns table (config_key text, value text) {
     return SELECT config_key, value FROM configs;
+}
+
+foreign procedure get_all_configs() returns table (config_key text, value text)
+
+procedure migrate_configs($dbid text) public owner {
+    for $row in SELECT config_key, value FROM get_all_configs[$dbid, 'all_configs_as_owner']() {
+        INSERT INTO configs (config_key, value)
+            VALUES ($row.config_key, $row.value);
+    }
+}
+
+// The sequence of inserting of tables is important
+procedure migrate_all_data($old_dbid text) public owner {
+    migrate_humans($old_dbid);
+    migrate_wallets($old_dbid);
+    migrate_credentials($old_dbid);
+    migrate_shared_credentials($old_dbid);
+    migrate_human_attributes($old_dbid);
+    migrate_shared_human_attrs($old_dbid);
+    migrate_inserters($old_dbid);
+    migrate_delegates($old_dbid);
+    migrate_external_grants($old_dbid);
+    migrate_write_grants($old_dbid); // WGs must be inserted before internal AGs
+    migrate_internal_grants($old_dbid);
+    migrate_configs($old_dbid);
 }


### PR DESCRIPTION
## Description

[Ticket](https://www.notion.so/idos-association/Access-grants-for-writing-data-11ea5ef8602546ab9f0a86d7f58bdf87?pvs=4)

## To implement

- [x] @caller can add a write grant
- [x] issuer (anyone, doesn't need to have idOS profile) can create a credential on behalf of a user if it has user’s WG
- [x] issuer can share a user’s credential (create a duplicate) if it has user’s WG
- [x] issuer can get_credential_shared (user is owner) if it has user’s WG (no AG needed)
- [ ] remove ability from inserter to create credentials. this requires changing in sdk, and in nautilus (in naultilus user has to create write grant for megalodon)

## How is this tested

Tested manually.
Plan to deploy it to staging (mostly it will be about new migration process).