### PR TITLE
Add content_hash argument to share_credential and share_credential_through_dag actions

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -483,6 +483,7 @@ CREATE OR REPLACE ACTION share_credential (
     $public_notes_signature TEXT,
     $broader_signature TEXT,
     $content TEXT,
+    $content_hash TEXT,
     $encryptor_public_key TEXT,
     $issuer_auth_public_key TEXT,
     $grantee_wallet_identifier TEXT,
@@ -511,7 +512,7 @@ CREATE OR REPLACE ACTION share_credential (
         $grantee_wallet_identifier,
         $id,
         $locked_until::int,
-        null,
+        $content_hash,
         'user',
         @caller
     );
@@ -555,6 +556,7 @@ CREATE OR REPLACE ACTION share_credential_through_dag (
     $issuer_auth_public_key TEXT,
     $encryptor_public_key TEXT,
     $content TEXT,
+    $content_hash TEXT,
     $public_notes TEXT,
     $public_notes_signature TEXT,
     $broader_signature TEXT,
@@ -626,7 +628,7 @@ CREATE OR REPLACE ACTION share_credential_through_dag (
         $dag_grantee_wallet_identifier,
         $id,
         $dag_locked_until::int,
-        null,
+        $content_hash,
         'dag_message',
         @caller
     );


### PR DESCRIPTION
During testing Mo realized that we have to have a possibility to save content_hash when sharing a credential by share_credential action.