### PR TITLE
Add index for passporting_club_memberships passporting_peer_id

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -135,6 +135,7 @@ CREATE TABLE IF NOT EXISTS passporting_club_memberships (
     FOREIGN KEY (passporting_club_id) REFERENCES passporting_clubs(id) ON DELETE CASCADE,
     FOREIGN KEY (passporting_peer_id) REFERENCES passporting_peers(id) ON DELETE CASCADE
 );
+CREATE INDEX IF NOT EXISTS passporting_memberships_peer_id ON passporting_club_memberships(passporting_peer_id);
 
 
 -- INSERTER AND DELEGATE ACTIONS


### PR DESCRIPTION
We have `PRIMARY KEY (passporting_club_id, passporting_peer_id)`
It automatically creates b-tree index for the columns, and `passporting_club_id` is covered by the index in expressions where it is involved alone. But `passporting_peer_id` is not.
As we [have](https://github.com/idos-network/idos-schema/blob/55dbf73dc846122122be0b380ab42caf3351d5aa/schema.sql#L1333) conditions like 
```
        WHERE passporting_peer_id = (
            SELECT id FROM passporting_peers WHERE issuer_public_key = @caller COLLATE NOCASE
        )
```
and 
``` JOIN passporting_club_memberships pcp ON p.id = pcp.passporting_peer_id```
we should add index for `passporting_peer_id`