### PR TITLE
Fix Case-Sensitive Key Comparison in Credential Creation

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -737,7 +737,7 @@ CREATE OR REPLACE ACTION create_credentials_by_dwg(
     $dwg_signature TEXT) PUBLIC {
 
     -- Check the content creator (encryptor) is the issuer that user delegated to issue the credential
-    if $issuer_auth_public_key != $dwg_issuer_public_key {
+    if lower($issuer_auth_public_key) != lower($dwg_issuer_public_key) {
         error('credentials issuer must be an issuer of delegated write grant (issuer_auth_public_key = dwg_issuer_public_key)');
     }
 


### PR DESCRIPTION
## Summary
This PR fixes a case-sensitivity issue in the create_credentials_by_dwg action where public key comparisons were failing due to inconsistent casing between issuer_auth_public_key and dwg_issuer_public_key.
## Changes

- File Modified: schema.sql
- Action: create_credentials_by_dwg
- Change: Wrapped both issuer_auth_public_key and dwg_issuer_public_key with lower() function before comparison

## Problem
The original comparison was case-sensitive, which could cause credential creation to fail even when the public keys were functionally identical but had different casing (e.g., 0xABC123 vs 0xabc123).
## Solution
By converting both keys to lowercase before comparison, we ensure that public keys with different casing are treated as equal, preventing unnecessary credential creation failures.
## Impact

- Bug Fix: Resolves case-sensitivity issues in credential creation
- User Experience: Improves reliability of credential issuance
- Backward Compatibility: No breaking changes; only affects comparison logic

## Testing
https://github.com/idos-network/idos-kgw/pull/70/files#diff-cb59873468f5f37561c52d9482004177029ad47d84a3c82f00823692b931899dR1024

This PR addresses a specific edge case that could cause credential creation to fail unnecessarily due to case sensitivity in public key comparisons.
