### PR TITLE
Multi-Instance Issuer Support

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -759,7 +759,7 @@ CREATE OR REPLACE ACTION create_credentials_by_dwg(
     -- Check the content creator (encryptor) of credentials is the issuer that user delegated to issue the credentials
     $the_same_issuer := false;
     for $row in SELECT 1 FROM delegates d1 INNER JOIN delegates d2 ON d1.inserter_id = d2.inserter_id
-        WHERE d1.address = lower($issuer_auth_public_key) AND d2.address = lower($dwg_issuer_public_key) LIMIT 1{
+        WHERE d1.address = lower($issuer_auth_public_key) AND d2.address = lower($dwg_issuer_public_key) LIMIT 1 {
         $the_same_issuer := true;
         break;
     }


### PR DESCRIPTION
## Summary
Allow different addresses of issuer of credentials and delegated write grants when both belong to the same inserter in the delegates table.

Deployed to `production`.

## Changes

1. `add_delegate_as_owner`: Store addresses in lowercase for consistency
2. `create_credentials_by_dwg`: Replace direct string comparison with database lookup to verify both addresses are delegates under the same `inserter_id`

## Tests
Added [here](https://github.com/idos-network/idos-kgw/pull/71)

# This is temporary solution

THis should be reverted after https://github.com/idos-network/idos-sdk-js/issues/1208 will be done