### PR TITLE
Fix: Improve gas and fee capture actions

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -1621,7 +1621,7 @@ CREATE OR REPLACE ACTION action_costing_idos_token($amount NUMERIC(78,0)) PUBLIC
 CREATE OR REPLACE ACTION get_issuer_fee($credential_id UUID) PUBLIC VIEW RETURNS (issuer_fee NUMERIC(78,0)) {
     FOR $row IN SELECT issuer_fee FROM credentials WHERE id = $credential_id {
         RETURN $row.issuer_fee;
-    };
+    }
 
     error('credential not found');
 };

--- a/schema_playground.sql
+++ b/schema_playground.sql
@@ -1616,7 +1616,7 @@ CREATE OR REPLACE ACTION action_costing_idos_token($amount NUMERIC(78,0)) PUBLIC
 CREATE OR REPLACE ACTION get_issuer_fee($credential_id UUID) PUBLIC VIEW RETURNS (issuer_fee NUMERIC(78,0)) {
     FOR $row IN SELECT issuer_fee FROM credentials WHERE id = $credential_id {
         RETURN $row.issuer_fee;
-    };
+    }
 
     error('credential not found');
 };

--- a/schema_production.sql
+++ b/schema_production.sql
@@ -1616,7 +1616,7 @@ CREATE OR REPLACE ACTION action_costing_idos_token($amount NUMERIC(78,0)) PUBLIC
 CREATE OR REPLACE ACTION get_issuer_fee($credential_id UUID) PUBLIC VIEW RETURNS (issuer_fee NUMERIC(78,0)) {
     FOR $row IN SELECT issuer_fee FROM credentials WHERE id = $credential_id {
         RETURN $row.issuer_fee;
-    };
+    }
 
     error('credential not found');
 };

--- a/schema_staging.sql
+++ b/schema_staging.sql
@@ -1616,7 +1616,7 @@ CREATE OR REPLACE ACTION action_costing_idos_token($amount NUMERIC(78,0)) PUBLIC
 CREATE OR REPLACE ACTION get_issuer_fee($credential_id UUID) PUBLIC VIEW RETURNS (issuer_fee NUMERIC(78,0)) {
     FOR $row IN SELECT issuer_fee FROM credentials WHERE id = $credential_id {
         RETURN $row.issuer_fee;
-    };
+    }
 
     error('credential not found');
 };


### PR DESCRIPTION
### Changes

**`capture_gas` action:**
- Moved wallet balance check inside the `IF $amount > 0` block to avoid unnecessary checks when allowance covers the full amount
- Use `greatest()` to prevent negative amounts when subtracting allowance

**`get_issuer_fee` action:**
- Added error handling: returns an error when credential is not found instead of returning null
- Changed from direct RETURN SELECT to FOR loop pattern

**`capture_fee` action:**
- Fixed fee calculation to use integer arithmetic: `($fee * 125)::NUMERIC(78,0) / 100::NUMERIC(78,0)` instead of `$fee * 1.25` for better precision

All changes have been applied consistently across all schema files.